### PR TITLE
Feature: Switch to a SharedFlow for network status

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ network connectivity using native APIs on Android and Apple devices, or by makin
 specified hosts.
 
 You can also
-view the generated KDoc at [docs.connectivity.jordond.dev](https://connectivity.jordond.dev)
+view the generated KDoc at [connectivity.jordond.dev](https://connectivity.jordond.dev)
 
 ## Table of Contents
 
@@ -22,6 +22,7 @@ view the generated KDoc at [docs.connectivity.jordond.dev](https://connectivity.
     - [Multiplatform - Device](#multiplatform---device)
     - [All supported platforms](#all-supported-platforms)
 - [Usage](#usage)
+  - [Options](#options)
     - [HTTP monitoring](#http-monitoring)
 - [Demo](#demo)
 - [Contributing](#contributing)
@@ -135,25 +136,16 @@ you can observe the network connectivity.
 val connectivity = Connectivity()
 connectivity.start()
 coroutineScope.launch {
-    connectivity.updates.collect { update ->
-        println("Is active: ${update.isActive}")
-
-        when (update.status) {
-            is NetworkStatus.Connected -> println("Connected to network")
-            is NetworkStatus.Disconnected -> println("Disconnected from network")
-        }
+  connectivity.statusUpdates.collect { status ->
+    when (status) {
+      is NetworkStatus.Connected -> println("Connected to network")
+      is NetworkStatus.Disconnected -> println("Disconnected from network")
     }
+  }
 }
 ```
 
-### Observing network connectivity
-
-Because the backing field for `Connectivity.updates` is a `StateFlow`, it requires a
-initial value to be emitted. This means that the first value emitted will be the *real* current
-network status. This is why the `isMonitoring` property is available on the `Connectivity.Update`.
-
-To get around this, you can use the synchronous `status()` function to get the current network
-status:
+You can also get the current connectivity status by invoking the suspended `status()` function:
 
 ```kotlin
 val connectivity = Connectivity()
@@ -166,21 +158,33 @@ coroutineScope.launch {
 }
 ```
 
-Or you can use the `Connectivity.activeUpdates` property, which is a `Flow<Connectivity.Status` that
-only emits status updates when the monitoring is active:
+Or you can use the `Connectivity.updates` property, which is a `StateFlow<Connectivity.Update` that
+emits a `Connectivity.Update` which contains the network status as well as whether the network
+monitoring is active.
 
 ```kotlin
 val connectivity = Connectivity()
 connectivity.start()
 coroutineScope.launch {
-    connectivity.activeUpdates.collect { status ->
-        // Handle status
+  connectivity.updates.collect { update ->
+    println("Monitoring is active: ${update.isActive}")
+
+    when (update.status) {
+      is NetworkStatus.Connected -> println("Connected to network")
+      is NetworkStatus.Disconnected -> println("Disconnected from network")
     }
+  }
 }
 ```
 
+**Note:** Because the backing field for `Connectivity.updates` is a `StateFlow`, it requires a
+initial value to be emitted. This means that the first value emitted will be the *real* current
+network status. This is why the `isActive` property is available on the `Connectivity.Update`.
+
 By default when you construct a `Connectivity` object, it will not automatically start monitoring
 network connectivity. You can enable this by passing in `ConnectivityOptions`():
+
+### Options
 
 ```kotlin
 val connectivity = Connectivity {
@@ -225,18 +229,18 @@ You can customize the HTTP monitoring like so:
 
 ```kotlin
 val connectivity = Connectivity {
-    urls("cloudflare.com", "my-own-domain.com")
-    port = 80
-    pollingIntervalMs = 10.minutes
-    timeoutMs = 5.seconds
+  urls("cloudflare.com", "my-own-domain.com") // Defaults to ["google.com", "github.com", "bing.com"]
+  port = 80 // Defaults to 443
+  pollingIntervalMs = 10.minutes // Defaults to 5 minutes
+  timeoutMs = 5.seconds // Defaults to 2 seconds
 
-    // Callback for when a poll is completed
-    onPollResult { result ->
-        when (result) {
-            is PollResult.Error -> println("Poll error: ${result.error}")
-            is PollResult.Response -> println("Poll http response: ${result.response}")
-        }
+  // Callback for when a poll is completed
+  onPollResult { result ->
+    when (result) {
+      is PollResult.Error -> println("Poll error: ${result.error}")
+      is PollResult.Response -> println("Poll http response: ${result.response}")
     }
+  }
 }
 ```
 

--- a/connectivity-core/api/android/connectivity-core.api
+++ b/connectivity-core/api/android/connectivity-core.api
@@ -1,6 +1,8 @@
 public abstract interface class dev/jordond/connectivity/Connectivity {
 	public abstract fun getActiveUpdates ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getStatusUpdates ()Lkotlinx/coroutines/flow/SharedFlow;
 	public abstract fun getUpdates ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isActive ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun start ()V
 	public abstract fun status (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop ()V

--- a/connectivity-core/api/jvm/connectivity-core.api
+++ b/connectivity-core/api/jvm/connectivity-core.api
@@ -1,6 +1,8 @@
 public abstract interface class dev/jordond/connectivity/Connectivity {
 	public abstract fun getActiveUpdates ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getStatusUpdates ()Lkotlinx/coroutines/flow/SharedFlow;
 	public abstract fun getUpdates ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isActive ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun start ()V
 	public abstract fun status (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop ()V

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
@@ -23,6 +23,11 @@ public interface Connectivity {
 
     public val isActive: StateFlow<Boolean>
 
+    @Deprecated(
+        message = "Use statusUpdates instead. Will be removed in a future release.",
+        replaceWith = ReplaceWith("statusUpdates"),
+        level = DeprecationLevel.WARNING,
+    )
     public val updates: StateFlow<Update>
 
     /**
@@ -60,6 +65,10 @@ public interface Connectivity {
      * @property status The [Status] of the connectivity.
      * @constructor Creates an update to the connectivity status.
      */
+    @Deprecated(
+        message = "This current usage of this class does not provide any additional value. Will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Poko
     public class Update(
         public val isActive: Boolean,

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
@@ -7,28 +7,34 @@ import dev.jordond.connectivity.internal.DefaultConnectivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
 
 /**
  * The Connectivity interface provides a way to monitor the network connectivity status.
  *
- * @property updates A [StateFlow] representing the current connectivity status.
+ * @property statusUpdates A [SharedFlow] representing the current connectivity status.
+ * @property isActive A [StateFlow] representing whether the connectivity monitoring is active.
+ * @property updates A [StateFlow] representing the current connectivity status and whether the monitoring is active.
  */
 public interface Connectivity {
+
+    public val statusUpdates: SharedFlow<Status>
+
+    public val isActive: StateFlow<Boolean>
 
     public val updates: StateFlow<Update>
 
     /**
      * A [Flow] representing status updates when the connectivity monitoring is active.
-     *
-     * This is a convenience method for filtering the [updates] [StateFlow] for active updates. Since
-     * the default value is [Status.Disconnected], and the real value won't be available until the
-     * monitoring starts, this flow will only emit updates when the monitoring is active.
      */
+    @Deprecated(
+        message = "Use statusUpdates instead. Will be removed in a future release.",
+        replaceWith = ReplaceWith("statusUpdates"),
+        level = DeprecationLevel.WARNING,
+    )
     public val activeUpdates: Flow<Status>
-        get() = updates.filter { it.isActive }.map { it.status }
+        get() = statusUpdates
 
     /**
      * Gets the current connectivity status.


### PR DESCRIPTION
Currently the network Flow is backed by a `StateFlow` which requires a default value. This default value is set to `Disconnected`. This was a design flaw since it doesn't reflect the actual state of the network.

Instead a new property `statusUpdates` has been added that is backed by a `SharedFlow`. This means there will only be updates once the state is actually known.

`Connectivity.updates` has been deprecated and will be replaced with `statusUpdates` in the future, since the `Connectivity.Update` is flawed.