### PR TITLE
chore: bump ktor to stable release

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ publish = "0.30.0"
 poko = "0.17.1"
 versions = "0.51.0"
 kotest = "5.9.1"
-ktor = "3.0.0-wasm2"
+ktor = "3.0.0"
 voyager = "1.1.0-beta03"
 stateHolder = "1.2.0"
 


### PR DESCRIPTION
since ktor 3 is officially stable, why not update to it?
should close both #41 and #57