### PR TITLE
Android - Registering for default network

### DIFF
--- a/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/internal/AndroidConnectivityProvider.kt
+++ b/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/internal/AndroidConnectivityProvider.kt
@@ -28,8 +28,6 @@ internal class AndroidConnectivityProvider(
             ?: return flowOf(Connectivity.Status.Disconnected)
 
         return callbackFlow {
-            val networkRequest = NetworkRequest.Builder().build()
-
             val networkCallback = object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
                     val capabilities = manager.getNetworkCapabilities(network)
@@ -51,7 +49,12 @@ internal class AndroidConnectivityProvider(
             }
 
             try {
-                manager.registerNetworkCallback(networkRequest, networkCallback)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    manager.registerDefaultNetworkCallback(networkCallback)
+                } else {
+                    val networkRequest = NetworkRequest.Builder().build()
+                    manager.registerNetworkCallback(networkRequest, networkCallback)
+                }
 
                 val initialStatus = manager.initialStatus()
                 trySend(initialStatus)


### PR DESCRIPTION
I've noticed an issue, in the the following scenario:

1. have both cellular data enabled and wifi connected
2. disable/disconnect wifi
3. device switches to using cellular data
4. the `onLost()` method gets called but sometimes neither `onAvailable()` nor `onCapabilitiesChanged()` method get called afterwards - leaving the state incorrectly as `Disconnected` until some other random change of the network happens

I'm not the only one who ran into this issue with `ConnectivityManager` (see [SO thread](https://stackoverflow.com/questions/55823422/android-connectivitymanager-onavailable-sometime-not-returned))

Since the library does not provide a way of monitoring all the "networks" but only the "one the app actually uses" (so to speak) registering for [`default` network](https://developer.android.com/develop/connectivity/network-ops/reading-network-state#listening-events) is more fitting than registering for [all networks](https://developer.android.com/develop/connectivity/network-ops/reading-network-state#additional-networks) and it works as expected = almost immediately after `onLost()` either `onAvailable()` or `onCapabilitiesChanged()` is called


if anybody is facing the same issue and needs it resolved in the meantime - feel free to use [published fork](https://central.sonatype.com/search?q=io.github.danicma%2Fconnectivity):
`io.github.danicma:connectivity` with version `1.1.4`