### PR TITLE
Chore: Remove deprecated Connectivity code

### DIFF
--- a/connectivity-compose/src/commonMain/kotlin/dev/jordond/connectivity/compose/ConnectivityState.kt
+++ b/connectivity-compose/src/commonMain/kotlin/dev/jordond/connectivity/compose/ConnectivityState.kt
@@ -48,7 +48,7 @@ public class ConnectivityState(
     private val scope: CoroutineScope,
 ) {
 
-    public var isMonitoring: Boolean by mutableStateOf(connectivity.isMonitoring.value)
+    public var isMonitoring: Boolean by mutableStateOf(connectivity.monitoring.value)
         private set
 
     /**
@@ -80,7 +80,7 @@ public class ConnectivityState(
 
     init {
         scope.launch {
-            connectivity.isMonitoring.collect { isMonitoring = it }
+            connectivity.monitoring.collect { isMonitoring = it }
         }
 
         scope.launch {

--- a/connectivity-core/api/android/connectivity-core.api
+++ b/connectivity-core/api/android/connectivity-core.api
@@ -47,19 +47,6 @@ public final class dev/jordond/connectivity/Connectivity$Status$Disconnected : d
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/jordond/connectivity/Connectivity$Update {
-	public fun <init> (ZLdev/jordond/connectivity/Connectivity$Status;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getStatus ()Ldev/jordond/connectivity/Connectivity$Status;
-	public fun hashCode ()I
-	public final fun isActive ()Z
-	public final fun isConnected ()Z
-	public final fun isDisconnected ()Z
-	public final fun isMetered ()Z
-	public final fun isMonitoring ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class dev/jordond/connectivity/ConnectivityKt {
 	public static final fun Connectivity (Ldev/jordond/connectivity/ConnectivityProvider;Ldev/jordond/connectivity/ConnectivityOptions;Lkotlinx/coroutines/CoroutineScope;)Ldev/jordond/connectivity/Connectivity;
 	public static final fun Connectivity (Ldev/jordond/connectivity/ConnectivityProvider;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/jordond/connectivity/Connectivity;

--- a/connectivity-core/api/android/connectivity-core.api
+++ b/connectivity-core/api/android/connectivity-core.api
@@ -1,15 +1,14 @@
 public abstract interface class dev/jordond/connectivity/Connectivity {
-	public abstract fun getActiveUpdates ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMonitoring ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getStatusUpdates ()Lkotlinx/coroutines/flow/SharedFlow;
-	public abstract fun getUpdates ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun isMonitoring ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isMonitoring ()Z
 	public abstract fun start ()V
 	public abstract fun status (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop ()V
 }
 
 public final class dev/jordond/connectivity/Connectivity$DefaultImpls {
-	public static fun getActiveUpdates (Ldev/jordond/connectivity/Connectivity;)Lkotlinx/coroutines/flow/Flow;
+	public static fun isMonitoring (Ldev/jordond/connectivity/Connectivity;)Z
 }
 
 public abstract interface class dev/jordond/connectivity/Connectivity$Status {

--- a/connectivity-core/api/jvm/connectivity-core.api
+++ b/connectivity-core/api/jvm/connectivity-core.api
@@ -47,19 +47,6 @@ public final class dev/jordond/connectivity/Connectivity$Status$Disconnected : d
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/jordond/connectivity/Connectivity$Update {
-	public fun <init> (ZLdev/jordond/connectivity/Connectivity$Status;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getStatus ()Ldev/jordond/connectivity/Connectivity$Status;
-	public fun hashCode ()I
-	public final fun isActive ()Z
-	public final fun isConnected ()Z
-	public final fun isDisconnected ()Z
-	public final fun isMetered ()Z
-	public final fun isMonitoring ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class dev/jordond/connectivity/ConnectivityKt {
 	public static final fun Connectivity (Ldev/jordond/connectivity/ConnectivityProvider;Ldev/jordond/connectivity/ConnectivityOptions;Lkotlinx/coroutines/CoroutineScope;)Ldev/jordond/connectivity/Connectivity;
 	public static final fun Connectivity (Ldev/jordond/connectivity/ConnectivityProvider;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/jordond/connectivity/Connectivity;

--- a/connectivity-core/api/jvm/connectivity-core.api
+++ b/connectivity-core/api/jvm/connectivity-core.api
@@ -1,15 +1,14 @@
 public abstract interface class dev/jordond/connectivity/Connectivity {
-	public abstract fun getActiveUpdates ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getMonitoring ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getStatusUpdates ()Lkotlinx/coroutines/flow/SharedFlow;
-	public abstract fun getUpdates ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun isMonitoring ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isMonitoring ()Z
 	public abstract fun start ()V
 	public abstract fun status (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun stop ()V
 }
 
 public final class dev/jordond/connectivity/Connectivity$DefaultImpls {
-	public static fun getActiveUpdates (Ldev/jordond/connectivity/Connectivity;)Lkotlinx/coroutines/flow/Flow;
+	public static fun isMonitoring (Ldev/jordond/connectivity/Connectivity;)Z
 }
 
 public abstract interface class dev/jordond/connectivity/Connectivity$Status {

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
@@ -6,7 +6,6 @@ import dev.jordond.connectivity.Connectivity.Status.Disconnected
 import dev.jordond.connectivity.internal.DefaultConnectivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -14,7 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
  * The Connectivity interface provides a way to monitor the network connectivity status.
  *
  * @property statusUpdates A [SharedFlow] representing the current connectivity status.
- * @property isMonitoring A [StateFlow] representing whether the connectivity monitoring is active.
+ * @property monitoring A [StateFlow] representing whether the connectivity monitoring is active.
  * @property updates A [StateFlow] representing the current connectivity status and whether
  * the monitoring is active.
  */
@@ -22,25 +21,10 @@ public interface Connectivity {
 
     public val statusUpdates: SharedFlow<Status>
 
-    public val isMonitoring: StateFlow<Boolean>
+    public val monitoring: StateFlow<Boolean>
 
-    @Deprecated(
-        message = "Use statusUpdates instead. Will be removed in a future release.",
-        replaceWith = ReplaceWith("statusUpdates"),
-        level = DeprecationLevel.WARNING,
-    )
-    public val updates: StateFlow<Update>
-
-    /**
-     * A [Flow] representing status updates when the connectivity monitoring is active.
-     */
-    @Deprecated(
-        message = "Use statusUpdates instead. Will be removed in a future release.",
-        replaceWith = ReplaceWith("statusUpdates"),
-        level = DeprecationLevel.WARNING,
-    )
-    public val activeUpdates: Flow<Status>
-        get() = statusUpdates
+    public val isMonitoring: Boolean
+        get() = monitoring.value
 
     /**
      * Gets the current connectivity status.

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
@@ -1,8 +1,5 @@
 package dev.jordond.connectivity
 
-import dev.drewhamilton.poko.Poko
-import dev.jordond.connectivity.Connectivity.Status.Connected
-import dev.jordond.connectivity.Connectivity.Status.Disconnected
 import dev.jordond.connectivity.internal.DefaultConnectivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,59 +39,6 @@ public interface Connectivity {
      * Stops monitoring the connectivity status.
      */
     public fun stop()
-
-    /**
-     * Represents an update to the connectivity status.
-     *
-     * @property isMonitoring A Boolean indicating whether the connectivity monitoring is active.
-     * @property status The [Status] of the connectivity.
-     * @constructor Creates an update to the connectivity status.
-     */
-    @Deprecated(
-        message = "This current usage of this class does not provide any additional value. Will be removed in a future release.",
-        level = DeprecationLevel.WARNING,
-    )
-    @Poko
-    public class Update(
-        public val isMonitoring: Boolean,
-        public val status: Status,
-    ) {
-
-        /**
-         * A Boolean indicating whether the connectivity monitoring is active.
-         */
-        @Deprecated(
-            message = "Use isMonitoring instead. Will be removed in a future release.",
-            replaceWith = ReplaceWith("isMonitoring"),
-            level = DeprecationLevel.WARNING,
-        )
-        public val isActive: Boolean = isMonitoring
-
-        /**
-         * A Boolean indicating whether the device is connected to the network.
-         */
-        public val isConnected: Boolean
-            get() = status is Connected
-
-        /**
-         * A Boolean indicating whether the device is connected to a metered network.
-         */
-        public val isMetered: Boolean
-            get() = status is Connected && status.metered
-
-        /**
-         * A Boolean indicating whether the device is disconnected from the network.
-         */
-        public val isDisconnected: Boolean
-            get() = status is Disconnected
-
-        @InternalConnectivityApi
-        public companion object {
-
-            @InternalConnectivityApi
-            public val default: Update = Update(isMonitoring = false, Disconnected)
-        }
-    }
 
     /**
      * Represents the connectivity status.

--- a/demo/composeApp/src/commonMain/kotlin/HomeModel.kt
+++ b/demo/composeApp/src/commonMain/kotlin/HomeModel.kt
@@ -11,13 +11,19 @@ class HomeModel : StateScreenModel<HomeModel.State>(State()) {
 
     init {
         screenModelScope.launch(Dispatchers.Default) {
-            connectivity.updates.collect { update ->
+            connectivity.monitoring.collect { isMonitoring ->
+                Logger.i { "Connectivity isMonitoring: $isMonitoring" }
+                updateState { state ->
+                    state.copy(monitoring = isMonitoring)
+                }
+            }
+        }
+
+        screenModelScope.launch(Dispatchers.Default) {
+            connectivity.statusUpdates.collect { update ->
                 Logger.i { "Connectivity update: $update" }
                 updateState { state ->
-                    state.copy(
-                        monitoring = update.isActive,
-                        status = if (update.isActive) update.status else state.status,
-                    )
+                    state.copy(status = update)
                 }
             }
         }


### PR DESCRIPTION
## BREAKING CHANGES

- Removed `Connectivity.Update` class, `Connectivity.updates` flow and `Connectivity.activeUpdates`.
    - This class was removed so you need to use `Connectivity.status`
    - To get the monitoring status use `Connectivity.monitoring` or `Connectivity.isMonitoring`.
- `Connectivity.isMonitoring: StateFlow<Boolean>` renamed to `Connectivity.monitoring`
- Added `Connectivity.isMonitoring: Boolean` to replace the `isMonitoring` from `Connectivity.Update`

## Migration

If you were using `Connectivity.updates` you need to migrate to the following:

```kotlin
// Old
connectivity.updates.collect { update ->
    updateState { state ->
        state.copy(
            monitoring = update.isActive,
            status = update,
        )
    }
}

// New
connectivity.statusUpdates.collect { status ->
    updateState { state ->
        state.copy(status = update, monitoring = connectivity.isMonitoring)
    }
}
```

If you need to also reactively update the monitoring status as well, you can do the following:

```kotlin
launch {
    connectivity.statusUpdates.collect { status ->
        updateState { state -> state.copy(status = update) }
    }
}

launch {
    connectivity.monitoring.collect { isMonitoring ->
        updateState { state ->  state.copy(monitoring = isMonitoring) }
    }
}
```

Or you can use `Flow.merge`:

```kotlin
connectivity.monitoring.combine(connectivity.statusUpdates) { isMonitoring, status ->
    updateState { state ->
        state.copy(status = update, monitoring = isMonitoring)
    }
}.collect()