### PR TITLE
Add tvOS Simulator Arm64 support to Multiplatform configuration

### DIFF
--- a/buildLogic/convention/src/main/kotlin/dev/jordond/connectivity/convention/Multiplatform.kt
+++ b/buildLogic/convention/src/main/kotlin/dev/jordond/connectivity/convention/Multiplatform.kt
@@ -64,6 +64,7 @@ internal fun KotlinMultiplatformExtension.configurePlatforms(
     if (platforms.contains(Platform.TvOS)) {
         tvosX64()
         tvosArm64()
+        tvosSimulatorArm64()
     }
 
     if (platforms.contains(Platform.Linux)) {


### PR DESCRIPTION
What’s changed:
- Enabled the tvOS Simulator arm64 target in the Multiplatform configuration.
- Retains existing tvOS x64 (Intel simulator) and arm64 (device) targets for broad coverage.