### PR TITLE
Feat: Cold Flow API

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,6 +26,7 @@ view the generated KDoc at [connectivity.jordond.dev](https://connectivity.jordo
   - [HTTP monitoring](#http-monitoring)
   - [Compose](#compose)
   - [Multiple Targets](#multiple-targets)
+  - [Cold Flow API](#cold-flow-api)
 - [Demo](#demo)
 - [Contributing](#contributing)
 - [License](#license)
@@ -318,6 +319,58 @@ fun MyApp() {
   }
 }
 ```
+
+### Cold Flow API
+
+Alongside the `Connectivity` object above, each module also exposes a cold `Flow<Connectivity.Status>`
+factory. Collecting the flow is what starts the platform listener (or HTTP polling loop), and
+cancelling collection stops it — there is nothing to `start()`, `stop()`, or `close()`.
+
+```kotlin
+deviceConnectivityFlow().collect { status ->
+  when (status) {
+    is Connectivity.Status.Connected -> println("Connected to network")
+    is Connectivity.Status.Disconnected -> println("Disconnected from network")
+  }
+}
+```
+
+Each collector runs its own, independent subscription — two collectors mean two platform
+listeners. If you need a single listener shared across multiple consumers, use `stateIn`/`shareIn`:
+
+```kotlin
+val status = deviceConnectivityFlow()
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = null)
+```
+
+For a one-off check, use `.first()`:
+
+```kotlin
+val status = deviceConnectivityFlow().first()
+```
+
+**`connectivity-http`**: the same three forms are available via `httpConnectivityFlow()`, but here
+`stateIn`/`shareIn` matters more — each additional collector means an additional polling loop, and
+therefore additional outbound HTTP requests at the configured interval:
+
+```kotlin
+// Prefer this when there's more than one consumer — one polling loop, shared.
+val status = httpConnectivityFlow()
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = null)
+
+// Each `collect` here starts its own independent polling loop.
+httpConnectivityFlow().collect { status -> /* ... */ }
+```
+
+Notes:
+
+- The flow runs in the collector's own coroutine context — there's no implicit
+  `Dispatchers.Default` the way the hot API used. Use `.flowOn()` if you need it on a specific
+  dispatcher.
+- The flow does not deduplicate emissions. Use `.distinctUntilChanged()` if repeated identical
+  statuses matter to you.
+- `HttpConnectivityOptions.options.autoStart` is ignored by `httpConnectivityFlow()` — collecting
+  the flow is what starts polling.
 
 ## Demo
 

--- a/README.MD
+++ b/README.MD
@@ -323,8 +323,12 @@ fun MyApp() {
 ### Cold Flow API
 
 Alongside the `Connectivity` object above, each module also exposes a cold `Flow<Connectivity.Status>`
-factory. Collecting the flow is what starts the platform listener (or HTTP polling loop), and
-cancelling collection stops it — there is nothing to `start()`, `stop()`, or `close()`.
+factory: `deviceConnectivityFlow()` in `connectivity-device`, `httpConnectivityFlow()` in
+`connectivity-http`, `androidConnectivityFlow()` / `appleConnectivityFlow()` in the platform modules,
+and `connectivityFlow(provider)` in `connectivity-core` for a custom `ConnectivityProvider`.
+
+Collecting the flow is what starts the platform listener (or HTTP polling loop), and cancelling
+collection stops it — the flow itself has no `start()`, `stop()` or `close()` to call.
 
 ```kotlin
 deviceConnectivityFlow().collect { status ->
@@ -354,12 +358,14 @@ val status = deviceConnectivityFlow().first()
 therefore additional outbound HTTP requests at the configured interval:
 
 ```kotlin
-// Prefer this when there's more than one consumer — one polling loop, shared.
-val status = httpConnectivityFlow()
+// Build the flow once, then share it — one polling loop across every consumer.
+val connectivity = httpConnectivityFlow(httpClient = myHttpClient)
+
+val status = connectivity
     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = null)
 
-// Each `collect` here starts its own independent polling loop.
-httpConnectivityFlow().collect { status -> /* ... */ }
+// Collecting it directly instead starts a second, independent polling loop.
+connectivity.collect { status -> /* ... */ }
 ```
 
 Notes:
@@ -367,6 +373,9 @@ Notes:
 - The flow runs in the collector's own coroutine context — there's no implicit
   `Dispatchers.Default` the way the hot API used. Use `.flowOn()` if you need it on a specific
   dispatcher.
+- `httpConnectivityFlow()` builds its default `HttpClient` eagerly, when you call the factory, and
+  never closes it — the same ownership rule the hot API uses. Pass your own `httpClient` (and close
+  it yourself) if you call the factory more than once, or the unused clients will leak.
 - The flow does not deduplicate emissions. Use `.distinctUntilChanged()` if repeated identical
   statuses matter to you.
 - `HttpConnectivityOptions.options.autoStart` is ignored by `httpConnectivityFlow()` — collecting

--- a/README.MD
+++ b/README.MD
@@ -327,8 +327,8 @@ factory: `deviceConnectivityFlow()` in `connectivity-device`, `httpConnectivityF
 `connectivity-http`, `androidConnectivityFlow()` / `appleConnectivityFlow()` in the platform modules,
 and `connectivityFlow(provider)` in `connectivity-core` for a custom `ConnectivityProvider`.
 
-Collecting the flow is what starts the platform listener (or HTTP polling loop), and cancelling
-collection stops it — the flow itself has no `start()`, `stop()` or `close()` to call.
+Collecting the flow starts the platform listener (or HTTP polling loop), and cancelling collection
+stops it. There is no `start()`, `stop()` or `close()` on the flow itself.
 
 ```kotlin
 deviceConnectivityFlow().collect { status ->
@@ -339,8 +339,8 @@ deviceConnectivityFlow().collect { status ->
 }
 ```
 
-Each collector runs its own, independent subscription — two collectors mean two platform
-listeners. If you need a single listener shared across multiple consumers, use `stateIn`/`shareIn`:
+Every collector gets its own subscription, so two collectors mean two platform listeners. To share a
+single listener across consumers, use `stateIn`/`shareIn`:
 
 ```kotlin
 val status = deviceConnectivityFlow()
@@ -353,33 +353,31 @@ For a one-off check, use `.first()`:
 val status = deviceConnectivityFlow().first()
 ```
 
-**`connectivity-http`**: the same three forms are available via `httpConnectivityFlow()`, but here
-`stateIn`/`shareIn` matters more — each additional collector means an additional polling loop, and
-therefore additional outbound HTTP requests at the configured interval:
+**`connectivity-http`**: the same three forms work with `httpConnectivityFlow()`, but sharing
+matters more here. Each extra collector is another polling loop, and another outbound request every
+interval:
 
 ```kotlin
-// Build the flow once, then share it — one polling loop across every consumer.
+// Build the flow once and share it, so there is only one polling loop.
 val connectivity = httpConnectivityFlow(httpClient = myHttpClient)
 
 val status = connectivity
     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = null)
 
-// Collecting it directly instead starts a second, independent polling loop.
+// Collecting it directly starts a second polling loop.
 connectivity.collect { status -> /* ... */ }
 ```
 
 Notes:
 
-- The flow runs in the collector's own coroutine context — there's no implicit
-  `Dispatchers.Default` the way the hot API used. Use `.flowOn()` if you need it on a specific
-  dispatcher.
-- `httpConnectivityFlow()` builds its default `HttpClient` eagerly, when you call the factory, and
-  never closes it — the same ownership rule the hot API uses. Pass your own `httpClient` (and close
-  it yourself) if you call the factory more than once, or the unused clients will leak.
-- The flow does not deduplicate emissions. Use `.distinctUntilChanged()` if repeated identical
-  statuses matter to you.
-- `HttpConnectivityOptions.options.autoStart` is ignored by `httpConnectivityFlow()` — collecting
-  the flow is what starts polling.
+- The flow runs in the collector's coroutine context. Unlike the hot API there is no implicit
+  `Dispatchers.Default`, so use `.flowOn()` if you need a specific dispatcher.
+- `httpConnectivityFlow()` builds its default `HttpClient` when you call the factory, not when the
+  flow is collected, and never closes it. This matches how the hot API treats the client. Pass your
+  own `httpClient` and close it yourself if you call the factory more than once.
+- Emissions are not deduplicated. Use `.distinctUntilChanged()` if repeated identical statuses
+  matter to you.
+- `HttpConnectivityOptions.options.autoStart` is ignored. Collecting the flow starts polling.
 
 ## Demo
 

--- a/connectivity-android/src/androidHostTest/kotlin/dev/jordond/connectivity/AndroidConnectivityFlowTest.kt
+++ b/connectivity-android/src/androidHostTest/kotlin/dev/jordond/connectivity/AndroidConnectivityFlowTest.kt
@@ -46,7 +46,7 @@ class AndroidConnectivityFlowTest {
 
     @Test
     fun doesNotResolveContextUntilCollected() = runTest {
-        // Undo the setup() mock — ContextProvider is genuinely uninitialized for this test.
+        // Undo the setup() mock so ContextProvider is genuinely uninitialized for this test.
         unmockkObject(ContextProvider.Companion)
 
         val flow = androidConnectivityFlow()

--- a/connectivity-android/src/androidHostTest/kotlin/dev/jordond/connectivity/AndroidConnectivityFlowTest.kt
+++ b/connectivity-android/src/androidHostTest/kotlin/dev/jordond/connectivity/AndroidConnectivityFlowTest.kt
@@ -1,0 +1,58 @@
+package dev.jordond.connectivity
+
+import android.content.Context
+import android.net.ConnectivityManager
+import dev.jordond.connectivity.tools.ContextProvider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class AndroidConnectivityFlowTest {
+
+    private lateinit var contextProvider: ContextProvider
+
+    @BeforeTest
+    fun setup() {
+        contextProvider = mockk()
+        mockkObject(ContextProvider.Companion)
+        every { ContextProvider.getInstance() } returns contextProvider
+        every { contextProvider.context } returns mockk {
+            // No ConnectivityManager, so the provider emits Disconnected without touching the
+            // Android framework, which isn't available in a host test.
+            every { getSystemService(Context.CONNECTIVITY_SERVICE) } returns null
+            every { getSystemService(ConnectivityManager::class.java) } returns null
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        unmockkObject(ContextProvider.Companion)
+    }
+
+    @Test
+    fun emitsDisconnectedWhenNoConnectivityManager() = runTest {
+        val status = androidConnectivityFlow().first()
+
+        status.shouldBeInstanceOf<Connectivity.Status.Disconnected>()
+    }
+
+    @Test
+    fun doesNotResolveContextUntilCollected() = runTest {
+        // Undo the setup() mock — ContextProvider is genuinely uninitialized for this test.
+        unmockkObject(ContextProvider.Companion)
+
+        val flow = androidConnectivityFlow()
+
+        shouldThrow<IllegalStateException> {
+            flow.first()
+        }
+    }
+}

--- a/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/AndroidConnectivityFlow.kt
+++ b/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/AndroidConnectivityFlow.kt
@@ -1,0 +1,21 @@
+package dev.jordond.connectivity
+
+import dev.jordond.connectivity.internal.AndroidConnectivityProvider
+import dev.jordond.connectivity.tools.ContextProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] for Android.
+ *
+ * The [android.content.Context] is resolved from [dev.jordond.connectivity.tools.ContextProvider]
+ * when the flow is collected, not when it is created — constructing this flow does not require an
+ * initialised `ContextProvider`, only collecting it does.
+ *
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public fun androidConnectivityFlow(): Flow<Connectivity.Status> = flow {
+    val context = ContextProvider.getInstance().context
+    emitAll(connectivityFlow(AndroidConnectivityProvider(context)))
+}

--- a/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/AndroidConnectivityFlow.kt
+++ b/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/AndroidConnectivityFlow.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.flow
  * Creates a cold [Flow] of [Connectivity.Status] for Android.
  *
  * The [android.content.Context] is resolved from [dev.jordond.connectivity.tools.ContextProvider]
- * when the flow is collected, not when it is created — constructing this flow does not require an
+ * when the flow is collected, not when it is created. Building this flow does not require an
  * initialised `ContextProvider`, only collecting it does.
  *
  * @return A cold [Flow] of [Connectivity.Status].

--- a/connectivity-apple/src/appleMain/kotlin/dev/jordond/connectivity/AppleConnectivityFlow.kt
+++ b/connectivity-apple/src/appleMain/kotlin/dev/jordond/connectivity/AppleConnectivityFlow.kt
@@ -1,0 +1,12 @@
+package dev.jordond.connectivity
+
+import dev.jordond.connectivity.internal.AppleConnectivityProvider
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] for Apple platforms.
+ *
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public fun appleConnectivityFlow(): Flow<Connectivity.Status> =
+    connectivityFlow(AppleConnectivityProvider)

--- a/connectivity-apple/src/appleTest/kotlin/dev/jordond/connectivity/AppleConnectivityFlowTest.kt
+++ b/connectivity-apple/src/appleTest/kotlin/dev/jordond/connectivity/AppleConnectivityFlowTest.kt
@@ -7,16 +7,14 @@ import kotlin.test.Test
 class AppleConnectivityFlowTest {
 
     /**
-     * Smoke test only — see §5.4's honesty clause. `AppleConnectivityProvider` drives a real
-     * `NWPathMonitor` with no seam to observe or fake it, matching the ceiling of the existing
-     * `AppleConnectivityTest`. There is no assertion here that can meaningfully fail against a
-     * flow-returning implementation; it exists to note the ceiling, not to pretend otherwise.
+     * Smoke test only. `AppleConnectivityProvider` drives a real `NWPathMonitor` with no seam to
+     * observe or fake it, so there is no assertion here that can fail against any implementation
+     * that returns a flow. This is the same ceiling the existing `AppleConnectivityTest` hits.
      *
-     * `startsNoMonitorUntilCollected` (5.4/2) is intentionally not written: constructing a fake
-     * `NWPathMonitor` seam is out of Phase 1 scope, and without one there is no way to observe
-     * whether the monitor started. The real coldness guarantee for this module comes from core
-     * test `ConnectivityFlowTest.isColdAndDoesNotSubscribeUntilCollected`, since
-     * `appleConnectivityFlow()` is a one-line delegation to `connectivityFlow(...)`.
+     * There is deliberately no test that the monitor stays unstarted until collection, because
+     * without a fake `NWPathMonitor` there is no way to observe it. That guarantee is covered in
+     * core by `ConnectivityFlowTest.isColdAndDoesNotSubscribeUntilCollected`, since
+     * `appleConnectivityFlow()` just delegates to `connectivityFlow(...)`.
      */
     @Test
     fun createsAFlow() {

--- a/connectivity-apple/src/appleTest/kotlin/dev/jordond/connectivity/AppleConnectivityFlowTest.kt
+++ b/connectivity-apple/src/appleTest/kotlin/dev/jordond/connectivity/AppleConnectivityFlowTest.kt
@@ -1,0 +1,27 @@
+package dev.jordond.connectivity
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.coroutines.flow.Flow
+import kotlin.test.Test
+
+class AppleConnectivityFlowTest {
+
+    /**
+     * Smoke test only — see §5.4's honesty clause. `AppleConnectivityProvider` drives a real
+     * `NWPathMonitor` with no seam to observe or fake it, matching the ceiling of the existing
+     * `AppleConnectivityTest`. There is no assertion here that can meaningfully fail against a
+     * flow-returning implementation; it exists to note the ceiling, not to pretend otherwise.
+     *
+     * `startsNoMonitorUntilCollected` (5.4/2) is intentionally not written: constructing a fake
+     * `NWPathMonitor` seam is out of Phase 1 scope, and without one there is no way to observe
+     * whether the monitor started. The real coldness guarantee for this module comes from core
+     * test `ConnectivityFlowTest.isColdAndDoesNotSubscribeUntilCollected`, since
+     * `appleConnectivityFlow()` is a one-line delegation to `connectivityFlow(...)`.
+     */
+    @Test
+    fun createsAFlow() {
+        val flow: Flow<Connectivity.Status> = appleConnectivityFlow()
+
+        flow.shouldNotBeNull()
+    }
+}

--- a/connectivity-core/api/jvm/connectivity-core.api
+++ b/connectivity-core/api/jvm/connectivity-core.api
@@ -48,6 +48,10 @@ public final class dev/jordond/connectivity/Connectivity$Status$Disconnected : d
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/jordond/connectivity/ConnectivityFlowKt {
+	public static final fun connectivityFlow (Ldev/jordond/connectivity/ConnectivityProvider;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class dev/jordond/connectivity/ConnectivityKt {
 	public static final fun Connectivity (Ldev/jordond/connectivity/ConnectivityProvider;Ldev/jordond/connectivity/ConnectivityOptions;Lkotlinx/coroutines/CoroutineScope;)Ldev/jordond/connectivity/Connectivity;
 	public static final fun Connectivity (Ldev/jordond/connectivity/ConnectivityProvider;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Ldev/jordond/connectivity/Connectivity;

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/ConnectivityFlow.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/ConnectivityFlow.kt
@@ -1,0 +1,16 @@
+package dev.jordond.connectivity
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] backed by the given [provider].
+ *
+ * The returned [Flow] is cold: no platform listener is registered until it is collected, and
+ * cancelling collection stops it. Each collector starts its own, independent subscription — see
+ * `shareIn`/`stateIn` if a single shared listener is needed across multiple collectors.
+ *
+ * @param provider The [ConnectivityProvider] to use for monitoring connectivity.
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public fun connectivityFlow(provider: ConnectivityProvider): Flow<Connectivity.Status> =
+    provider.monitor()

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/ConnectivityFlow.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/ConnectivityFlow.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.flow.flow
  * Creates a cold [Flow] of [Connectivity.Status] backed by the given [provider].
  *
  * The returned [Flow] is cold: no platform listener is registered until it is collected, and
- * cancelling collection stops it. Each collector starts its own, independent subscription — see
- * `shareIn`/`stateIn` if a single shared listener is needed across multiple collectors.
+ * cancelling collection stops it. Every collector gets its own subscription, so use
+ * `shareIn`/`stateIn` if a single listener should be shared across collectors.
  *
  * [ConnectivityProvider.monitor] is invoked once per collection rather than once per call to this
  * function. Its contract is to *start* monitoring, and implementations may allocate platform

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/ConnectivityFlow.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/ConnectivityFlow.kt
@@ -1,6 +1,8 @@
 package dev.jordond.connectivity
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 
 /**
  * Creates a cold [Flow] of [Connectivity.Status] backed by the given [provider].
@@ -9,8 +11,14 @@ import kotlinx.coroutines.flow.Flow
  * cancelling collection stops it. Each collector starts its own, independent subscription — see
  * `shareIn`/`stateIn` if a single shared listener is needed across multiple collectors.
  *
+ * [ConnectivityProvider.monitor] is invoked once per collection rather than once per call to this
+ * function. Its contract is to *start* monitoring, and implementations may allocate platform
+ * resources before returning their flow, so calling it eagerly would both leak those resources for
+ * a flow that is never collected and hand every collector the same underlying listener.
+ *
  * @param provider The [ConnectivityProvider] to use for monitoring connectivity.
  * @return A cold [Flow] of [Connectivity.Status].
  */
-public fun connectivityFlow(provider: ConnectivityProvider): Flow<Connectivity.Status> =
-    provider.monitor()
+public fun connectivityFlow(provider: ConnectivityProvider): Flow<Connectivity.Status> = flow {
+    emitAll(provider.monitor())
+}

--- a/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/ConnectivityFlowTest.kt
+++ b/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/ConnectivityFlowTest.kt
@@ -128,9 +128,9 @@ class ConnectivityFlowTest {
     }
 
     /**
-     * Pins decision E (no dedupe) so Phase 2 — which shares this flow behind `shareIn` to
-     * reimplement the hot API — cannot silently drift from today's hot behaviour, where
-     * Android's `onCapabilitiesChanged` fires repeated, non-distinct `Connected` values.
+     * The hot API does not dedupe, and Android's `onCapabilitiesChanged` does fire repeated
+     * `Connected` values. Reimplementing the hot API on top of this flow later means the two have
+     * to agree, so pin the lack of deduplication now.
      */
     @Test
     fun doesNotDeduplicateRepeatedStatuses() = runTest {
@@ -150,7 +150,7 @@ class ConnectivityFlowTest {
      * A provider that counts calls to [monitor] itself, not just collections of a pre-built flow.
      *
      * [ConnectivityProvider.monitor]'s contract is to *start* monitoring, and real implementations
-     * allocate platform resources in it — `AppleConnectivityProvider` calls `nw_path_monitor_create`
+     * allocate platform resources in it. `AppleConnectivityProvider` calls `nw_path_monitor_create`
      * before returning its `callbackFlow`. A fixture built with `ConnectivityProvider(someFlow)`
      * cannot see when `monitor()` runs, so it cannot tell a cold factory from an eager one.
      */

--- a/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/ConnectivityFlowTest.kt
+++ b/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/ConnectivityFlowTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -32,51 +33,39 @@ class ConnectivityFlowTest {
 
     @Test
     fun isColdAndDoesNotSubscribeUntilCollected() = runTest {
-        var subscriptions = 0
-        val provider = ConnectivityProvider(
-            flow {
-                subscriptions++
-                emit(Connectivity.Status.Connected(false))
-            },
-        )
+        val provider = CountingProvider()
 
         val flow = connectivityFlow(provider)
-        subscriptions shouldBe 0
+        provider.monitorCalls shouldBe 0
 
         flow.first()
-        subscriptions shouldBe 1
+        provider.monitorCalls shouldBe 1
     }
 
     @Test
     fun subscribesOncePerCollector() = runTest {
-        var subscriptions = 0
-        val provider = ConnectivityProvider(
-            flow {
-                subscriptions++
-                emit(Connectivity.Status.Connected(false))
-            },
-        )
+        val provider = CountingProvider()
 
         val flow = connectivityFlow(provider)
         flow.first()
         flow.first()
 
-        subscriptions shouldBe 2
+        provider.monitorCalls shouldBe 2
     }
 
     @Test
     fun unsubscribesSourceWhenCollectionCancelled() = runTest {
         var finallyRuns = 0
-        val provider = ConnectivityProvider(
-            flow {
+        val provider = object : ConnectivityProvider {
+            override fun monitor(): Flow<Connectivity.Status> = flow {
                 try {
                     emit(Connectivity.Status.Connected(false))
                     awaitCancellation()
                 } finally {
                     finallyRuns++
                 }
-            },
-        )
+            }
+        }
 
         // A bare TestScope Job does not fire invokeOnCompletion, so the collecting job needs a
         // real Job on an unconfined dispatcher for cancellation to actually propagate here.
@@ -155,5 +144,23 @@ class ConnectivityFlowTest {
             Connectivity.Status.Connected(false),
             Connectivity.Status.Connected(false),
         )
+    }
+
+    /**
+     * A provider that counts calls to [monitor] itself, not just collections of a pre-built flow.
+     *
+     * [ConnectivityProvider.monitor]'s contract is to *start* monitoring, and real implementations
+     * allocate platform resources in it — `AppleConnectivityProvider` calls `nw_path_monitor_create`
+     * before returning its `callbackFlow`. A fixture built with `ConnectivityProvider(someFlow)`
+     * cannot see when `monitor()` runs, so it cannot tell a cold factory from an eager one.
+     */
+    private class CountingProvider : ConnectivityProvider {
+        var monitorCalls = 0
+            private set
+
+        override fun monitor(): Flow<Connectivity.Status> {
+            monitorCalls++
+            return flowOf(Connectivity.Status.Connected(false))
+        }
     }
 }

--- a/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/ConnectivityFlowTest.kt
+++ b/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/ConnectivityFlowTest.kt
@@ -1,0 +1,159 @@
+package dev.jordond.connectivity
+
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectivityFlowTest {
+
+    @Test
+    fun emitsProviderStatusesInOrder() = runTest {
+        val provider = ConnectivityProvider(
+            flowOf(Connectivity.Status.Connected(false), Connectivity.Status.Disconnected),
+        )
+
+        val result = connectivityFlow(provider).toList()
+
+        result shouldBe listOf(Connectivity.Status.Connected(false), Connectivity.Status.Disconnected)
+    }
+
+    @Test
+    fun isColdAndDoesNotSubscribeUntilCollected() = runTest {
+        var subscriptions = 0
+        val provider = ConnectivityProvider(
+            flow {
+                subscriptions++
+                emit(Connectivity.Status.Connected(false))
+            },
+        )
+
+        val flow = connectivityFlow(provider)
+        subscriptions shouldBe 0
+
+        flow.first()
+        subscriptions shouldBe 1
+    }
+
+    @Test
+    fun subscribesOncePerCollector() = runTest {
+        var subscriptions = 0
+        val provider = ConnectivityProvider(
+            flow {
+                subscriptions++
+                emit(Connectivity.Status.Connected(false))
+            },
+        )
+
+        val flow = connectivityFlow(provider)
+        flow.first()
+        flow.first()
+
+        subscriptions shouldBe 2
+    }
+
+    @Test
+    fun unsubscribesSourceWhenCollectionCancelled() = runTest {
+        var finallyRuns = 0
+        val provider = ConnectivityProvider(
+            flow {
+                try {
+                    emit(Connectivity.Status.Connected(false))
+                    awaitCancellation()
+                } finally {
+                    finallyRuns++
+                }
+            },
+        )
+
+        // A bare TestScope Job does not fire invokeOnCompletion, so the collecting job needs a
+        // real Job on an unconfined dispatcher for cancellation to actually propagate here.
+        val scope = CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler))
+        val job = scope.launch {
+            connectivityFlow(provider).collect { }
+        }
+
+        job.cancel()
+        job.join()
+
+        finallyRuns shouldBe 1
+    }
+
+    @Test
+    fun firstReturnsOneOffStatusAndUnsubscribes() = runTest {
+        var finallyRuns = 0
+        val provider = ConnectivityProvider(
+            flow {
+                try {
+                    emit(Connectivity.Status.Connected(false))
+                    awaitCancellation()
+                } finally {
+                    finallyRuns++
+                }
+            },
+        )
+
+        val status = connectivityFlow(provider).first()
+
+        status shouldBe Connectivity.Status.Connected(false)
+        finallyRuns shouldBe 1
+    }
+
+    /**
+     * #262 regression pin. A hot implementation that attaches a permanent child job to the
+     * caller's scope (the pre-#262-fix `DefaultConnectivity` shape) would hang this job forever.
+     */
+    @Test
+    fun doesNotOutliveOrBlockTheCallingScope() = runTest {
+        val provider = ConnectivityProvider(
+            flow {
+                emit(Connectivity.Status.Connected(false))
+                awaitCancellation()
+            },
+        )
+
+        val scope = CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler))
+        val job = scope.launch {
+            connectivityFlow(provider).first()
+        }
+        job.join()
+
+        job.isCompleted.shouldBeTrue()
+        scope.isActive.shouldBeTrue()
+
+        var launchedAfter = false
+        scope.launch { launchedAfter = true }.join()
+        launchedAfter.shouldBeTrue()
+    }
+
+    /**
+     * Pins decision E (no dedupe) so Phase 2 — which shares this flow behind `shareIn` to
+     * reimplement the hot API — cannot silently drift from today's hot behaviour, where
+     * Android's `onCapabilitiesChanged` fires repeated, non-distinct `Connected` values.
+     */
+    @Test
+    fun doesNotDeduplicateRepeatedStatuses() = runTest {
+        val provider = ConnectivityProvider(
+            flowOf(Connectivity.Status.Connected(false), Connectivity.Status.Connected(false)),
+        )
+
+        val result = connectivityFlow(provider).toList()
+
+        result shouldBe listOf(
+            Connectivity.Status.Connected(false),
+            Connectivity.Status.Connected(false),
+        )
+    }
+}

--- a/connectivity-device/src/androidMain/kotlin/dev/jordond/connectivity/DeviceConnectivityFlow.android.kt
+++ b/connectivity-device/src/androidMain/kotlin/dev/jordond/connectivity/DeviceConnectivityFlow.android.kt
@@ -1,0 +1,12 @@
+package dev.jordond.connectivity
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] for Android platforms.
+ *
+ * This function is platform-specific and its implementation is provided by Android platform.
+ *
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public actual fun deviceConnectivityFlow(): Flow<Connectivity.Status> = androidConnectivityFlow()

--- a/connectivity-device/src/appleMain/kotlin/dev/jordond/connectivity/DeviceConnectivityFlow.apple.kt
+++ b/connectivity-device/src/appleMain/kotlin/dev/jordond/connectivity/DeviceConnectivityFlow.apple.kt
@@ -1,0 +1,12 @@
+package dev.jordond.connectivity
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] for iOS platforms.
+ *
+ * This function is platform-specific and its implementation is provided by iOS platform.
+ *
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public actual fun deviceConnectivityFlow(): Flow<Connectivity.Status> = appleConnectivityFlow()

--- a/connectivity-device/src/commonMain/kotlin/dev/jordond/connectivity/DeviceConnectivityFlow.kt
+++ b/connectivity-device/src/commonMain/kotlin/dev/jordond/connectivity/DeviceConnectivityFlow.kt
@@ -1,0 +1,13 @@
+package dev.jordond.connectivity
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] for device platforms.
+ *
+ * Delegates to `androidConnectivityFlow()` on Android and `appleConnectivityFlow()` on Apple
+ * platforms.
+ *
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public expect fun deviceConnectivityFlow(): Flow<Connectivity.Status>

--- a/connectivity-http/api/jvm/connectivity-http.api
+++ b/connectivity-http/api/jvm/connectivity-http.api
@@ -1,3 +1,10 @@
+public final class dev/jordond/connectivity/HttpConnectivityFlowKt {
+	public static final fun httpConnectivityFlow (Ldev/jordond/connectivity/HttpConnectivityOptions;Lio/ktor/client/HttpClient;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun httpConnectivityFlow (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun httpConnectivityFlow$default (Ldev/jordond/connectivity/HttpConnectivityOptions;Lio/ktor/client/HttpClient;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun httpConnectivityFlow$default (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class dev/jordond/connectivity/HttpConnectivityKt {
 	public static final fun Connectivity (Ldev/jordond/connectivity/HttpConnectivityOptions;Lkotlinx/coroutines/CoroutineScope;Lio/ktor/client/HttpClient;)Ldev/jordond/connectivity/Connectivity;
 	public static final fun Connectivity (Lkotlinx/coroutines/CoroutineScope;Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;)Ldev/jordond/connectivity/Connectivity;

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivityFlow.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivityFlow.kt
@@ -18,6 +18,10 @@ import kotlin.time.Duration.Companion.milliseconds
  * **Note:** [HttpConnectivityOptions.options]' `autoStart` is ignored — collecting the flow
  * is what starts polling.
  *
+ * **Note:** the default [httpClient] is built eagerly, when this function is called rather than
+ * when the flow is collected, and is never closed — the same ownership rule the hot API uses. Pass
+ * your own [HttpClient] if you call this factory more than once.
+ *
  * @param options The [HttpConnectivityOptions] used to configure the connectivity monitoring.
  * Defaults to a new [HttpConnectivityOptions] instance.
  * @param httpClient The [HttpClient] used to make HTTP requests. Defaults to a new [HttpClient]

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivityFlow.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivityFlow.kt
@@ -1,0 +1,50 @@
+package dev.jordond.connectivity
+
+import dev.jordond.connectivity.internal.HttpStatusChecker
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] that polls HTTP endpoints for connectivity.
+ *
+ * The returned [Flow] is cold: no request is made until it is collected, and cancelling
+ * collection stops polling. Each collector runs its own, independent polling loop — see
+ * `shareIn`/`stateIn` if a single shared loop is needed across multiple collectors, since each
+ * additional collector otherwise means additional outbound requests at the configured interval.
+ *
+ * **Note:** [HttpConnectivityOptions.options]' `autoStart` is ignored — collecting the flow
+ * is what starts polling.
+ *
+ * @param options The [HttpConnectivityOptions] used to configure the connectivity monitoring.
+ * Defaults to a new [HttpConnectivityOptions] instance.
+ * @param httpClient The [HttpClient] used to make HTTP requests. Defaults to a new [HttpClient]
+ * instance.
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public fun httpConnectivityFlow(
+    options: HttpConnectivityOptions = HttpConnectivityOptions(),
+    httpClient: HttpClient = HttpClient(),
+): Flow<Connectivity.Status> = flow {
+    val statusChecker = HttpStatusChecker(options, httpClient)
+    while (true) {
+        emit(statusChecker.check())
+        delay(options.pollingIntervalMs.milliseconds)
+    }
+}
+
+/**
+ * Creates a cold [Flow] of [Connectivity.Status] that polls HTTP endpoints for connectivity,
+ * using a builder for the [HttpConnectivityOptions].
+ *
+ * @param httpClient The [HttpClient] used to make HTTP requests. Defaults to a new [HttpClient]
+ * instance.
+ * @param options A builder function for creating the [HttpConnectivityOptions].
+ * @return A cold [Flow] of [Connectivity.Status].
+ */
+public fun httpConnectivityFlow(
+    httpClient: HttpClient = HttpClient(),
+    options: HttpConnectivityOptions.Builder.() -> Unit,
+): Flow<Connectivity.Status> = httpConnectivityFlow(HttpConnectivityOptions.build(options), httpClient)

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivityFlow.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivityFlow.kt
@@ -11,15 +11,14 @@ import kotlin.time.Duration.Companion.milliseconds
  * Creates a cold [Flow] of [Connectivity.Status] that polls HTTP endpoints for connectivity.
  *
  * The returned [Flow] is cold: no request is made until it is collected, and cancelling
- * collection stops polling. Each collector runs its own, independent polling loop — see
- * `shareIn`/`stateIn` if a single shared loop is needed across multiple collectors, since each
- * additional collector otherwise means additional outbound requests at the configured interval.
+ * collection stops polling. Every collector runs its own polling loop, so each one adds outbound
+ * requests at the configured interval. Use `shareIn`/`stateIn` to share a single loop.
  *
- * **Note:** [HttpConnectivityOptions.options]' `autoStart` is ignored — collecting the flow
- * is what starts polling.
+ * **Note:** [HttpConnectivityOptions.options]' `autoStart` is ignored. Collecting the flow starts
+ * polling.
  *
- * **Note:** the default [httpClient] is built eagerly, when this function is called rather than
- * when the flow is collected, and is never closed — the same ownership rule the hot API uses. Pass
+ * **Note:** the default [httpClient] is built when this function is called rather than when the
+ * flow is collected, and is never closed, which matches how the hot API treats the client. Pass
  * your own [HttpClient] if you call this factory more than once.
  *
  * @param options The [HttpConnectivityOptions] used to configure the connectivity monitoring.

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/internal/HttpConnectivity.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/internal/HttpConnectivity.kt
@@ -3,13 +3,8 @@ package dev.jordond.connectivity.internal
 import dev.drewhamilton.poko.Poko
 import dev.jordond.connectivity.Connectivity
 import dev.jordond.connectivity.HttpConnectivityOptions
-import dev.jordond.connectivity.PollResult
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.timeout
-import io.ktor.client.request.request
 import io.ktor.http.URLProtocol
-import io.ktor.http.isSuccess
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
@@ -32,6 +27,7 @@ internal class HttpConnectivity(
     private val httpClient: HttpClient,
 ) : Connectivity {
     private val scope = ConnectivityScope(parentScope)
+    private val statusChecker = HttpStatusChecker(httpOptions, httpClient)
 
     private var job: Job? = null
 
@@ -51,7 +47,7 @@ internal class HttpConnectivity(
     }
 
     override suspend fun status(): Connectivity.Status {
-        return checkConnection().also { status ->
+        return statusChecker.check().also { status ->
             _statusUpdates.emit(status)
         }
     }
@@ -75,7 +71,7 @@ internal class HttpConnectivity(
 
     internal fun forcePoll() {
         scope.launch {
-            checkConnection().also { status ->
+            statusChecker.check().also { status ->
                 _statusUpdates.emit(status)
             }
         }
@@ -84,63 +80,10 @@ internal class HttpConnectivity(
     private fun poll() {
         job = scope.launch {
             while (isActive) {
-                val status = checkConnection()
+                val status = statusChecker.check()
                 _statusUpdates.emit(status)
                 delay(httpOptions.pollingIntervalMs.milliseconds)
             }
-        }
-    }
-
-    private suspend fun checkConnection(): Connectivity.Status {
-        var isConnected = false
-        for (url in httpOptions.urls) {
-            isConnected = makeRequest(url, httpOptions.port)
-            if (isConnected) break
-        }
-
-        return if (isConnected) Connectivity.Status.Connected(metered = false)
-        else Connectivity.Status.Disconnected
-    }
-
-    private suspend fun makeRequest(url: String, port: Int): Boolean {
-        val (protocol, host) = getProtocolAndHost(url, port)
-
-        try {
-            val response = httpClient.request {
-                url {
-                    this.protocol = protocol
-                    this.host = host
-                    this.port = port
-                    method = httpOptions.method
-                }
-
-                timeout {
-                    requestTimeoutMillis = httpOptions.timeoutMs
-                }
-            }
-
-            notifyPollResult(PollResult.Response(response))
-
-            return response.status.isSuccess()
-        } catch (cause: Throwable) {
-            if (cause is CancellationException) throw cause
-
-            notifyPollResult(PollResult.Error(cause))
-            return false
-        }
-    }
-
-    /**
-     * Invokes the consumer's [HttpConnectivityOptions.onPollResult] callback, a throwing callback
-     * must not stop the polling or bring down the scope it is running in.
-     */
-    private fun notifyPollResult(result: PollResult) {
-        try {
-            httpOptions.onPollResult?.invoke(result)
-        } catch (cause: CancellationException) {
-            throw cause
-        } catch (_: Throwable) {
-            // Ignored, the callback is a notification and its failures are the consumer's problem.
         }
     }
 }

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/internal/HttpStatusChecker.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/internal/HttpStatusChecker.kt
@@ -1,0 +1,75 @@
+package dev.jordond.connectivity.internal
+
+import dev.jordond.connectivity.Connectivity
+import dev.jordond.connectivity.HttpConnectivityOptions
+import dev.jordond.connectivity.PollResult
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.request
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Performs a single HTTP connectivity check against [options]' urls, using [httpClient].
+ *
+ * Shared by the hot [HttpConnectivity] and the cold `httpConnectivityFlow`, so both paths have
+ * identical request/retry/callback semantics.
+ */
+internal class HttpStatusChecker(
+    private val options: HttpConnectivityOptions,
+    private val httpClient: HttpClient,
+) {
+
+    suspend fun check(): Connectivity.Status {
+        var isConnected = false
+        for (url in options.urls) {
+            isConnected = makeRequest(url, options.port)
+            if (isConnected) break
+        }
+
+        return if (isConnected) Connectivity.Status.Connected(metered = false)
+        else Connectivity.Status.Disconnected
+    }
+
+    private suspend fun makeRequest(url: String, port: Int): Boolean {
+        val (protocol, host) = getProtocolAndHost(url, port)
+
+        try {
+            val response = httpClient.request {
+                this.url {
+                    this.protocol = protocol
+                    this.host = host
+                    this.port = port
+                    method = options.method
+                }
+
+                timeout {
+                    requestTimeoutMillis = options.timeoutMs
+                }
+            }
+
+            notifyPollResult(PollResult.Response(response))
+
+            return response.status.isSuccess()
+        } catch (cause: Throwable) {
+            if (cause is CancellationException) throw cause
+
+            notifyPollResult(PollResult.Error(cause))
+            return false
+        }
+    }
+
+    /**
+     * Invokes the consumer's [HttpConnectivityOptions.onPollResult] callback, a throwing callback
+     * must not stop the polling or bring down the scope it is running in.
+     */
+    private fun notifyPollResult(result: PollResult) {
+        try {
+            options.onPollResult?.invoke(result)
+        } catch (cause: CancellationException) {
+            throw cause
+        } catch (_: Throwable) {
+            // Ignored, the callback is a notification and its failures are the consumer's problem.
+        }
+    }
+}

--- a/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/HttpConnectivityFlowTest.kt
+++ b/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/HttpConnectivityFlowTest.kt
@@ -1,0 +1,156 @@
+package dev.jordond.connectivity
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.http.HttpStatusCode.Companion.InternalServerError
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+class HttpConnectivityFlowTest {
+
+    private lateinit var mockEngine: MockEngine
+    private lateinit var httpClient: HttpClient
+
+    @BeforeTest
+    fun setup() {
+        mockEngine = MockEngine { respondOk() }
+        httpClient = HttpClient(mockEngine)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        httpClient.close()
+        mockEngine.close()
+    }
+
+    @Test
+    fun emitsConnectedOnSuccessfulResponse() = runTest {
+        val status = httpConnectivityFlow(httpClient = httpClient).first()
+
+        status.shouldBeInstanceOf<Connectivity.Status.Connected>()
+    }
+
+    @Test
+    fun emitsDisconnectedOnErrorResponse() = runTest {
+        mockEngine = MockEngine { respondError(InternalServerError) }
+        httpClient = HttpClient(mockEngine)
+
+        val status = httpConnectivityFlow(httpClient = httpClient).first()
+
+        status.shouldBeInstanceOf<Connectivity.Status.Disconnected>()
+    }
+
+    @Test
+    fun emitsDisconnectedWhenRequestThrows() = runTest {
+        mockEngine = MockEngine { throw IllegalStateException("Test exception") }
+        httpClient = HttpClient(mockEngine)
+
+        val status = httpConnectivityFlow(httpClient = httpClient).first()
+
+        status.shouldBeInstanceOf<Connectivity.Status.Disconnected>()
+    }
+
+    @Test
+    fun makesNoRequestUntilCollected() = runTest {
+        httpConnectivityFlow(httpClient = httpClient)
+
+        mockEngine.requestHistory.shouldBeEmpty()
+    }
+
+    /**
+     * Pins decision F (emit, then delay) — parity with the existing `HttpConnectivity.poll()`
+     * loop. An hour-long interval would make `.first()` hang if the loop delayed before its
+     * first emission.
+     *
+     * Runs on a real dispatcher with a real-time bound: `runTest`'s virtual clock auto-skips
+     * `delay()`, so a virtual-time version of this test cannot distinguish "emit then delay"
+     * from "delay then emit" — both return instantly regardless of ordering.
+     */
+    @Test
+    fun emitsBeforeTheFirstDelay() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(3.seconds) {
+                val options = HttpConnectivityOptions.build { pollingIntervalMs = 60 * 60_000L }
+
+                val status = httpConnectivityFlow(options, httpClient).first()
+
+                status.shouldBeInstanceOf<Connectivity.Status.Connected>()
+            }
+        }
+    }
+
+    /**
+     * The riskiest test in the plan (§7.1) — real dispatcher + real-time bound, matching the
+     * mitigation the existing `HttpConnectivityTest` already uses for MockEngine-backed tests,
+     * since `runTest`'s virtual clock does not reliably coordinate with MockEngine's dispatch.
+     */
+    @Test
+    fun pollsRepeatedlyAtTheConfiguredInterval() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(5.seconds) {
+                val options = HttpConnectivityOptions.build { pollingIntervalMs = 10 }
+
+                httpConnectivityFlow(options, httpClient).take(3).toList()
+
+                mockEngine.requestHistory.size shouldBe 3
+            }
+        }
+    }
+
+    @Test
+    fun invokesOnPollResultPerRequest() = runTest {
+        var callbackCount = 0
+        val options = HttpConnectivityOptions.build { onPollResult { callbackCount++ } }
+
+        httpConnectivityFlow(options, httpClient).first()
+
+        callbackCount shouldBe mockEngine.requestHistory.size
+    }
+
+    @Test
+    fun throwingOnPollResultDoesNotStopTheFlow() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(5.seconds) {
+                val options = HttpConnectivityOptions.build {
+                    pollingIntervalMs = 10
+                    onPollResult { error("Consumer callback blew up") }
+                }
+
+                val statuses = httpConnectivityFlow(options, httpClient).take(2).toList()
+
+                statuses.size shouldBe 2
+            }
+        }
+    }
+
+    @Test
+    fun runsAnIndependentLoopPerCollector() = runTest {
+        val flow = httpConnectivityFlow(httpClient = httpClient)
+
+        flow.first()
+        flow.first()
+
+        mockEngine.requestHistory.size shouldBe 2
+    }
+
+    @Test
+    fun builderOverloadConfiguresTheSameFlow() = runTest {
+        httpConnectivityFlow(httpClient) { url("example.com") }.first()
+
+        mockEngine.requestHistory.first().url.host shouldBe "example.com"
+    }
+}

--- a/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/HttpConnectivityFlowTest.kt
+++ b/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/HttpConnectivityFlowTest.kt
@@ -72,13 +72,11 @@ class HttpConnectivityFlowTest {
     }
 
     /**
-     * Pins decision F (emit, then delay) — parity with the existing `HttpConnectivity.poll()`
-     * loop. An hour-long interval would make `.first()` hang if the loop delayed before its
-     * first emission.
+     * The loop emits before it delays, matching the existing `HttpConnectivity.poll()`. With an
+     * hour-long interval, `.first()` would hang if that order were reversed.
      *
-     * Runs on a real dispatcher with a real-time bound: `runTest`'s virtual clock auto-skips
-     * `delay()`, so a virtual-time version of this test cannot distinguish "emit then delay"
-     * from "delay then emit" — both return instantly regardless of ordering.
+     * This runs on a real dispatcher with a real timeout because `runTest`'s virtual clock skips
+     * `delay()`, which makes both orderings return instantly and the test useless.
      */
     @Test
     fun emitsBeforeTheFirstDelay() = runTest {
@@ -94,9 +92,9 @@ class HttpConnectivityFlowTest {
     }
 
     /**
-     * The riskiest test in the plan (§7.1) — real dispatcher + real-time bound, matching the
-     * mitigation the existing `HttpConnectivityTest` already uses for MockEngine-backed tests,
-     * since `runTest`'s virtual clock does not reliably coordinate with MockEngine's dispatch.
+     * Real dispatcher and real timeout, the same workaround `HttpConnectivityTest` already uses
+     * for its MockEngine tests, since `runTest`'s virtual clock does not coordinate with
+     * MockEngine's dispatch.
      */
     @Test
     fun pollsRepeatedlyAtTheConfiguredInterval() = runTest {
@@ -118,7 +116,7 @@ class HttpConnectivityFlowTest {
 
         httpConnectivityFlow(options, httpClient).first()
 
-        // Concrete counts, not counter-vs-counter — `0 shouldBe 0` would pass if the poll never ran.
+        // Concrete counts, not one counter against the other, which would pass at 0 == 0.
         mockEngine.requestHistory.size shouldBe 1
         callbackCount shouldBe 1
     }

--- a/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/HttpConnectivityFlowTest.kt
+++ b/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/HttpConnectivityFlowTest.kt
@@ -118,7 +118,9 @@ class HttpConnectivityFlowTest {
 
         httpConnectivityFlow(options, httpClient).first()
 
-        callbackCount shouldBe mockEngine.requestHistory.size
+        // Concrete counts, not counter-vs-counter — `0 shouldBe 0` would pass if the poll never ran.
+        mockEngine.requestHistory.size shouldBe 1
+        callbackCount shouldBe 1
     }
 
     @Test

--- a/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/internal/HttpStatusCheckerTest.kt
+++ b/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/internal/HttpStatusCheckerTest.kt
@@ -1,0 +1,52 @@
+package dev.jordond.connectivity.internal
+
+import dev.jordond.connectivity.HttpConnectivityOptions
+import io.kotest.assertions.throwables.shouldThrow
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+/**
+ * Pins the two `CancellationException` rethrows in [HttpStatusChecker].
+ *
+ * Both are load-bearing and neither is covered by [HttpConnectivityTest] or by the cold
+ * `HttpConnectivityFlowTest`: deleting either one leaves the whole module green while silently
+ * turning "the collector was cancelled mid-request" into a plain `Disconnected` emission, which
+ * breaks structured concurrency for both the hot and the cold call sites that now share this class.
+ */
+class HttpStatusCheckerTest {
+
+    private lateinit var httpClient: HttpClient
+
+    @AfterTest
+    fun cleanup() {
+        httpClient.close()
+    }
+
+    @Test
+    fun rethrowsCancellationFromTheRequest() = runTest {
+        httpClient = HttpClient(MockEngine { throw CancellationException("cancelled mid-request") })
+        val checker = HttpStatusChecker(HttpConnectivityOptions(), httpClient)
+
+        // Without the `if (cause is CancellationException) throw cause` guard in makeRequest, the
+        // generic catch reports PollResult.Error and returns Disconnected instead.
+        shouldThrow<CancellationException> { checker.check() }
+    }
+
+    @Test
+    fun rethrowsCancellationFromThePollResultCallback() = runTest {
+        httpClient = HttpClient(MockEngine { respondOk() })
+        val options = HttpConnectivityOptions.build {
+            onPollResult { throw CancellationException("cancelled in callback") }
+        }
+        val checker = HttpStatusChecker(options, httpClient)
+
+        // Without the CancellationException branch in notifyPollResult, the `catch (_: Throwable)`
+        // swallow below it eats the cancellation and check() returns normally.
+        shouldThrow<CancellationException> { checker.check() }
+    }
+}


### PR DESCRIPTION
Adds cold `Flow<Connectivity.Status>` factories next to the existing hot `Connectivity` API. Collecting starts the platform listener, cancelling stops it. Nothing to start, stop or close.

- `connectivityFlow(provider)` in core
- `httpConnectivityFlow(options, httpClient)` plus a builder overload in http
- `deviceConnectivityFlow()` in device
- `androidConnectivityFlow()` and `appleConnectivityFlow()` in the platform modules

Moved the HTTP request logic into an internal `HttpStatusChecker` so the hot and cold paths share it. `HttpConnectivityTest` is unmodified.

Two things to check:

1. `monitor()` runs per collection rather than per factory call. Calling it eagerly leaked an `nw_path_monitor` and dispatch queue on Apple when the flow was never collected, and gave every collector of the same flow the same monitor.
2. `connectivity-device` has no test source sets, so `:connectivity-device:allTests` passes without running anything.