### PR TITLE
Chore: Deprecate hot Connectivity API

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,281 @@
+# Migration Guide
+
+Starting in 2.7.0, the hot `Connectivity` API (`start()`, `stop()`, `close()`, `monitoring`, and the
+factory functions that take a `CoroutineScope`) is deprecated in favor of the cold `Flow` API added
+in 2.6.0. This document covers what's changing, why, and how to migrate.
+
+## Timeline
+
+- **2.7.0**: the hot API is deprecated at `WARNING`. Nothing changes at runtime; every call still
+  behaves exactly as it did in 2.6.0. The warnings are advance notice.
+- **2.8.0**: the same deprecations move to `ERROR`. Code that still calls the hot API stops
+  compiling until you migrate or suppress the warning yourself.
+- **3.0.0**: the deprecated surface is deleted. `Connectivity` stops implementing `AutoCloseable`.
+
+## Why
+
+`Connectivity` used to take a `CoroutineScope` it did not own, and use it to turn a cold source into
+a hot `SharedFlow`. That one decision produced most of the library's lifecycle machinery
+(`start()`, `stop()`, `close()`, `monitoring`) and two production issues:
+[#208](https://github.com/jordond/connectivity/issues/208), where `stop()` cancelled the caller's
+own scope, and [#262](https://github.com/jordond/connectivity/issues/262), where an internal scope
+added to fix #208 ended up hanging `status()` forever. A cold `Flow` has no lifecycle of its own to
+get wrong: the listener starts when you collect and stops when you cancel, the same as any other
+`Flow`. Those cold factories (`connectivityFlow`, `httpConnectivityFlow`, `deviceConnectivityFlow`,
+`androidConnectivityFlow`, `appleConnectivityFlow`) shipped in 2.6.0. 2.7.0 marks the hot API
+deprecated instead of removing it outright, so you have two full minor versions to move over.
+
+## What's changing
+
+### `connectivity-core`
+
+| Deprecated | Replacement |
+|---|---|
+| `Connectivity(provider, options, scope)` | `connectivityFlow(provider)` |
+| `Connectivity(provider, scope) { ... }` (options builder) | `connectivityFlow(provider)` |
+| `Connectivity.start()` | collect `connectivityFlow(provider)` |
+| `Connectivity.stop()` | cancel the collecting coroutine |
+| `Connectivity.close()` | nothing to close, remove the call |
+| `Connectivity.monitoring` / `isMonitoring` | the collector already knows whether it's collecting; use `SharingStarted.WhileSubscribed` if you need shared "is anyone listening" semantics |
+
+`close()` only shipped in 2.6.0, to make releasable the internal scope added for the #262 fix. The
+cold API doesn't allocate anything that needs releasing, so it's deprecated here too, one minor
+after it was added. That's intentional, not an oversight.
+
+Not deprecated: `statusUpdates`, `status()`, `Status` and its subtypes, `ConnectivityProvider`,
+`ConnectivityProvider(flow)`, `asProvider()`, `ConnectivityOptions` and its builder.
+
+`statusUpdates` keeps its name all the way into 3.0, but its type changes from `SharedFlow<Status>`
+to `Flow<Status>` once the hot implementation is deleted. That change ships in 3.0.0, not 2.7.0, so
+there's no 2.x deprecation warning for it, only the type-change itself when 3.0.0 lands.
+
+### `connectivity-http`
+
+| Deprecated | Replacement |
+|---|---|
+| `Connectivity(options, scope, httpClient)` | `httpConnectivityFlow(options, httpClient)` |
+| `Connectivity(scope, httpClient) { ... }` (options builder) | `httpConnectivityFlow(httpClient) { ... }` |
+| `Connectivity.force()` | `status()`, or start a new collection |
+
+### `connectivity-device`
+
+| Deprecated | Replacement |
+|---|---|
+| `Connectivity(options, scope)` | `deviceConnectivityFlow()` |
+| `Connectivity(scope) { ... }` (options builder) | `deviceConnectivityFlow()` |
+
+Not deprecated: `deviceConnectivityFlow()`.
+
+### `connectivity-android`
+
+| Deprecated | Replacement |
+|---|---|
+| `Connectivity(options, scope)` | `androidConnectivityFlow()` |
+| `AndroidConnectivity(options, scope)` | `androidConnectivityFlow()` |
+| `Connectivity(scope) { ... }` (options builder) | `androidConnectivityFlow()` |
+
+### `connectivity-apple`
+
+| Deprecated | Replacement |
+|---|---|
+| `Connectivity(options, scope)` | `appleConnectivityFlow()` |
+| `AppleConnectivity(options, scope)` | `appleConnectivityFlow()` |
+| `Connectivity(scope) { ... }` (options builder) | `appleConnectivityFlow()` |
+
+### `connectivity-compose`
+
+| Deprecated | Replacement |
+|---|---|
+| `rememberConnectivityState(connectivity, scope)` | `connectivityFlow(provider).collectAsStateWithLifecycle(null)` |
+| `ConnectivityState.isMonitoring` | no longer meaningful, collection state is now the caller's |
+| `ConnectivityState.forceCheck()` | call `status()` on your `Connectivity`, or start a new collection |
+| `ConnectivityState.startMonitoring()` | collection starts the listener |
+| `ConnectivityState.stopMonitoring()` | cancel the collection |
+
+Not deprecated: `ConnectivityState` itself, `status`, `isConnected`, `isMetered`, `isDisconnected`.
+
+### `connectivity-compose-device` and `connectivity-compose-http`
+
+| Deprecated | Replacement |
+|---|---|
+| `rememberConnectivityState(options, scope)` | `deviceConnectivityFlow()` / `httpConnectivityFlow(...)` + `collectAsStateWithLifecycle(null)` |
+| `rememberConnectivityState(scope) { ... }` (options builder) | same |
+
+## Migrating your code
+
+### Plain collection
+
+Before:
+
+```kotlin
+val connectivity = Connectivity()
+connectivity.start()
+coroutineScope.launch {
+  connectivity.statusUpdates.collect { status ->
+    when (status) {
+      is Connectivity.Status.Connected -> println("Connected to network")
+      is Connectivity.Status.Disconnected -> println("Disconnected from network")
+    }
+  }
+}
+```
+
+After:
+
+```kotlin
+coroutineScope.launch {
+  deviceConnectivityFlow().collect { status ->
+    when (status) {
+      is Connectivity.Status.Connected -> println("Connected to network")
+      is Connectivity.Status.Disconnected -> println("Disconnected from network")
+    }
+  }
+}
+```
+
+There's no `Connectivity` instance to build or `start()`. Collecting the flow starts the listener,
+and cancelling `coroutineScope` stops it.
+
+### Shared collection
+
+The old hot API's `statusUpdates` was already a shared `SharedFlow`. Every collector on the same
+`Connectivity` instance saw the same emissions without you doing anything. The cold flow doesn't
+share by default; each collector gets its own subscription and its own platform listener. If you
+want sharing back, opt into it explicitly.
+
+Before:
+
+```kotlin
+val connectivity = Connectivity(scope = viewModelScope) {
+  autoStart = true
+}
+
+// Both collectors share the same underlying listener automatically.
+coroutineScope.launch { connectivity.statusUpdates.collect { /* ... */ } }
+coroutineScope.launch { connectivity.statusUpdates.collect { /* ... */ } }
+```
+
+After:
+
+```kotlin
+val status = deviceConnectivityFlow()
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = null)
+
+// Both collectors now share status, backed by one listener.
+coroutineScope.launch { status.collect { /* ... */ } }
+coroutineScope.launch { status.collect { /* ... */ } }
+```
+
+### One-off check
+
+Before:
+
+```kotlin
+val connectivity = Connectivity()
+val status = connectivity.status()
+```
+
+After:
+
+```kotlin
+val status = deviceConnectivityFlow().first()
+```
+
+`status()` isn't going anywhere and still works. But if the only thing you ever did with a
+`Connectivity` instance was call `status()` once, you don't need to construct one, or a
+`CoroutineScope`, at all.
+
+### Compose
+
+Before:
+
+```kotlin
+@Composable
+fun MyApp() {
+  val state = rememberConnectivityState {
+    autoStart = true
+  }
+
+  when (state.status) {
+    is Connectivity.Status.Connected -> Text("Connected to network")
+    is Connectivity.Status.Disconnected -> Text("Disconnected from network")
+    else -> {}
+  }
+}
+```
+
+After:
+
+```kotlin
+@Composable
+fun MyApp() {
+  val flow = remember { deviceConnectivityFlow() }
+  val status by flow.collectAsStateWithLifecycle(null)
+
+  when (status) {
+    is Connectivity.Status.Connected -> Text("Connected to network")
+    is Connectivity.Status.Disconnected -> Text("Disconnected from network")
+    else -> {}
+  }
+}
+```
+
+Wrap the flow itself in `remember`, not just the collection. `collectAsStateWithLifecycle` keys on
+the flow instance, so calling `deviceConnectivityFlow()` directly inside the composable would tear
+down and re-register the platform listener on every recomposition. `collectAsStateWithLifecycle`
+comes from `androidx.lifecycle:lifecycle-runtime-compose`, which this library doesn't pull in for
+you, so add it to your own project.
+
+### HTTP polling
+
+Before:
+
+```kotlin
+val connectivity = Connectivity(httpClient = myHttpClient) {
+  urls("cloudflare.com", "my-own-domain.com")
+  pollingIntervalMs = 10.minutes
+}
+connectivity.start()
+
+coroutineScope.launch {
+  connectivity.statusUpdates.collect { status -> /* ... */ }
+}
+```
+
+After:
+
+```kotlin
+val statusFlow = httpConnectivityFlow(httpClient = myHttpClient) {
+  urls("cloudflare.com", "my-own-domain.com")
+  pollingIntervalMs = 10.minutes
+}.shareIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), replay = 1)
+
+coroutineScope.launch {
+  statusFlow.collect { status -> /* ... */ }
+}
+```
+
+Do this one deliberately. `httpConnectivityFlow()` is cold, so every collector runs its own polling
+loop against `myHttpClient`. Two collectors on the plain flow means two sets of outbound requests
+every `pollingIntervalMs`, not one. `shareIn` (or `stateIn`, if you only need the latest status)
+guarantees there's exactly one loop no matter how many collectors you have.
+
+`httpConnectivityFlow` still accepts `HttpConnectivityOptions`, but it ignores `autoStart`. Setting
+it has no effect either way, because collecting the flow is what starts polling. Drop it from your
+builder block when you migrate.
+
+## What is not changing
+
+- `Connectivity.Status`, `Status.Connected`, `Status.Disconnected`, and the properties on them
+  (`isConnected`, `isMetered`, `isDisconnected`).
+- `ConnectivityProvider`, `ConnectivityProvider(flow)`, and `Flow<Status>.asProvider()`.
+- `statusUpdates` and `status()` as names. `status()` keeps its signature. `statusUpdates`'s type
+  changes from `SharedFlow<Status>` to `Flow<Status>` in 3.0.0, not before.
+- `ConnectivityOptions` and its builder.
+- `ConnectivityState`, and its `status`, `isConnected`, `isMetered`, and `isDisconnected` properties.
+- The platform behavior behind all of the above: the same native network callbacks on Android and
+  Apple platforms, and the same HTTP polling logic, just reachable through a `Flow` instead of a
+  `SharedFlow`.
+- The cold flow factories added in 2.6.0 (`connectivityFlow`, `httpConnectivityFlow`,
+  `deviceConnectivityFlow`, `androidConnectivityFlow`, `appleConnectivityFlow`). This guide is about
+  migrating onto them, not away from them.

--- a/README.MD
+++ b/README.MD
@@ -153,6 +153,12 @@ See the [demo](demo) project for a complete example.
 
 ## Usage
 
+**Deprecated:** As of 2.7.0 the `Connectivity` object below (`start()`, `stop()`, `close()`,
+`monitoring`, and the factory functions that take a `CoroutineScope`) is deprecated in favor of the
+[Cold Flow API](#cold-flow-api). It still works exactly as before, nothing changes at runtime, but
+new code should use the cold flow factories instead. See [MIGRATION.md](MIGRATION.md) for the full
+rationale and migration guide.
+
 Basic usage of Connectivity is simple, you just need an instance of the `Connectivity` object, then
 you can observe the network connectivity.
 
@@ -250,6 +256,10 @@ val connectivity = Connectivity {
 Connectivity also provides support for Compose Multiplatform. To use it you will have to make sure
 you add the dependencies for the `connectivity-compose-x` modules.
 
+**Deprecated:** `rememberConnectivityState` and its lifecycle members (`isMonitoring`,
+`forceCheck()`, `startMonitoring()`, `stopMonitoring()`) are deprecated as of 2.7.0. See
+[MIGRATION.md](MIGRATION.md) for the `collectAsStateWithLifecycle` equivalent.
+
 Then you can use it like so:
 
 **Note:** This composable is provided by either `connectivity-compose-device`
@@ -275,6 +285,10 @@ fun MyApp() {
 
 If you need to support both Device and HTTP monitoring in the same project, you will have to do
 something similar to [this](#all-supported-platforms).
+
+**Deprecated:** The pattern below builds a `Connectivity` object through the deprecated
+`CoroutineScope`-based factories. See [MIGRATION.md](MIGRATION.md) for the cold flow equivalent,
+which does the same thing with an `expect`/`actual` flow factory instead.
 
 Example:
 

--- a/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/AndroidConnectivity.kt
+++ b/connectivity-android/src/androidMain/kotlin/dev/jordond/connectivity/AndroidConnectivity.kt
@@ -14,6 +14,11 @@ import kotlinx.coroutines.Dispatchers
  * Defaults to a new [CoroutineScope] with [Dispatchers.Default].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use androidConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     options: ConnectivityOptions = ConnectivityOptions(),
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -32,6 +37,11 @@ public fun Connectivity(
  * Defaults to a new [CoroutineScope] with [Dispatchers.Default].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use androidConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun AndroidConnectivity(
     options: ConnectivityOptions = ConnectivityOptions(),
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -45,6 +55,11 @@ public fun AndroidConnectivity(
  * @param options A lambda function that configures the [ConnectivityOptions.Builder].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use androidConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     options: ConnectivityOptions.Builder.() -> Unit,

--- a/connectivity-apple/src/appleMain/kotlin/dev/jordond/connectivity/AppleConnectivity.kt
+++ b/connectivity-apple/src/appleMain/kotlin/dev/jordond/connectivity/AppleConnectivity.kt
@@ -13,6 +13,11 @@ import kotlinx.coroutines.Dispatchers
  * Defaults to a new [CoroutineScope] with [Dispatchers.Default].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use appleConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     options: ConnectivityOptions = ConnectivityOptions(),
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -27,7 +32,11 @@ public fun Connectivity(
  * Defaults to a new [CoroutineScope] with [Dispatchers.Default].
  * @return A [Connectivity] instance.
  */
-@Suppress("FunctionName")
+@Suppress("FunctionName", "DEPRECATION")
+@Deprecated(
+    "Use appleConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun AppleConnectivity(
     options: ConnectivityOptions = ConnectivityOptions(),
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -41,6 +50,11 @@ public fun AppleConnectivity(
  * @param options A lambda function that configures the [ConnectivityOptions.Builder].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use appleConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     options: ConnectivityOptions.Builder.() -> Unit,

--- a/connectivity-compose-device/src/commonMain/kotlin/dev/jordond/connectivity/compose/DeviceConnectivityState.kt
+++ b/connectivity-compose-device/src/commonMain/kotlin/dev/jordond/connectivity/compose/DeviceConnectivityState.kt
@@ -14,6 +14,11 @@ import kotlinx.coroutines.CoroutineScope
  * @param scope The [CoroutineScope] in which to launch the network status monitoring coroutine.
  * @return A [ConnectivityState] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use deviceConnectivityFlow().collectAsStateWithLifecycle(null) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 @Composable
 public fun rememberConnectivityState(
     options: ConnectivityOptions = remember { ConnectivityOptions() },
@@ -35,6 +40,11 @@ public fun rememberConnectivityState(
  * @param block A lambda function to configure the [ConnectivityOptions] for the network status monitoring.
  * @return A [ConnectivityState] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use deviceConnectivityFlow().collectAsStateWithLifecycle(null) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 @Composable
 public fun rememberConnectivityState(
     scope: CoroutineScope = rememberCoroutineScope(),

--- a/connectivity-compose-http/src/commonMain/kotlin/dev/jordond/connectivity/compose/HttpConnectivityState.kt
+++ b/connectivity-compose-http/src/commonMain/kotlin/dev/jordond/connectivity/compose/HttpConnectivityState.kt
@@ -17,6 +17,11 @@ import kotlinx.coroutines.CoroutineScope
  * @param httpClient The [HttpClient] instance to use for network requests.
  * @return A [ConnectivityState] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use httpConnectivityFlow(...).collectAsStateWithLifecycle(null) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 @Composable
 public fun rememberConnectivityState(
     options: HttpConnectivityOptions = remember { HttpConnectivityOptions() },
@@ -40,6 +45,11 @@ public fun rememberConnectivityState(
  * @param block A lambda function to configure the [HttpConnectivityOptions] instance.
  * @return A [ConnectivityState] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use httpConnectivityFlow(httpClient) { ... }.collectAsStateWithLifecycle(null) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 @Composable
 public fun rememberConnectivityState(
     scope: CoroutineScope = rememberCoroutineScope(),

--- a/connectivity-compose/src/commonMain/kotlin/dev/jordond/connectivity/compose/ConnectivityState.kt
+++ b/connectivity-compose/src/commonMain/kotlin/dev/jordond/connectivity/compose/ConnectivityState.kt
@@ -22,6 +22,10 @@ import kotlinx.coroutines.launch
  * @param scope The [CoroutineScope] in which to launch the network status monitoring coroutine.
  * @return A [ConnectivityState] instance.
  */
+@Deprecated(
+    "Use connectivityFlow(provider).collectAsStateWithLifecycle(null) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 @Composable
 public fun rememberConnectivityState(
     connectivity: Connectivity,
@@ -43,11 +47,16 @@ public fun rememberConnectivityState(
  */
 @Poko
 @Stable
+@Suppress("DEPRECATION")
 public class ConnectivityState(
     private val connectivity: Connectivity,
     private val scope: CoroutineScope,
 ) {
 
+    @Deprecated(
+        "No longer meaningful, collection state is now the caller's. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public var isMonitoring: Boolean by mutableStateOf(connectivity.monitoring.value)
         private set
 
@@ -91,6 +100,10 @@ public class ConnectivityState(
     /**
      * Force a check of the current network status.
      */
+    @Deprecated(
+        "Call status() on your Connectivity, or start a new collection. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public fun forceCheck() {
         scope.launch { connectivity.status() }
     }
@@ -98,6 +111,10 @@ public class ConnectivityState(
     /**
      * Start monitoring the network status.
      */
+    @Deprecated(
+        "Collection starts the listener. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public fun startMonitoring() {
         connectivity.start()
     }
@@ -105,6 +122,10 @@ public class ConnectivityState(
     /**
      * Stop monitoring the network status.
      */
+    @Deprecated(
+        "Cancel the collection instead. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public fun stopMonitoring() {
         connectivity.stop()
     }

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/Connectivity.kt
@@ -18,8 +18,19 @@ public interface Connectivity : AutoCloseable {
 
     public val statusUpdates: SharedFlow<Status>
 
+    @Deprecated(
+        "The collector already knows whether it's collecting. Use SharingStarted.WhileSubscribed " +
+            "if you need shared \"is anyone listening\" semantics. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public val monitoring: StateFlow<Boolean>
 
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        "The collector already knows whether it's collecting. Use SharingStarted.WhileSubscribed " +
+            "if you need shared \"is anyone listening\" semantics. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public val isMonitoring: Boolean
         get() = monitoring.value
 
@@ -33,11 +44,19 @@ public interface Connectivity : AutoCloseable {
     /**
      * Starts monitoring the connectivity status.
      */
+    @Deprecated(
+        "Collect connectivityFlow(provider) instead. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public fun start()
 
     /**
      * Stops monitoring the connectivity status.
      */
+    @Deprecated(
+        "Cancel the coroutine collecting connectivityFlow(provider) instead. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     public fun stop()
 
     /**
@@ -46,6 +65,10 @@ public interface Connectivity : AutoCloseable {
      * Unlike [stop] this is terminal, a closed instance cannot be started again. The
      * [CoroutineScope] this instance was created with is left untouched.
      */
+    @Deprecated(
+        "There is nothing to close, remove the call. See " +
+            "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+    )
     override fun close()
 
     /**
@@ -93,6 +116,10 @@ public interface Connectivity : AutoCloseable {
  * @param scope The [CoroutineScope] in which to launch the connectivity monitoring coroutine.
  * @return A [Connectivity] instance.
  */
+@Deprecated(
+    "Use connectivityFlow(provider) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     provider: ConnectivityProvider,
     options: ConnectivityOptions = ConnectivityOptions(),
@@ -109,6 +136,11 @@ public fun Connectivity(
  * @param options A builder function for creating the [ConnectivityOptions].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use connectivityFlow(provider) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     provider: ConnectivityProvider,
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),

--- a/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/internal/DefaultConnectivity.kt
+++ b/connectivity-core/src/commonMain/kotlin/dev/jordond/connectivity/internal/DefaultConnectivity.kt
@@ -4,6 +4,7 @@ import dev.drewhamilton.poko.Poko
 import dev.jordond.connectivity.Connectivity
 import dev.jordond.connectivity.ConnectivityOptions
 import dev.jordond.connectivity.ConnectivityProvider
+import dev.jordond.connectivity.connectivityFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @Poko
+@Suppress("OVERRIDE_DEPRECATION")
 internal class DefaultConnectivity(
     parentScope: CoroutineScope,
     private val provider: ConnectivityProvider,
@@ -42,7 +44,7 @@ internal class DefaultConnectivity(
     }
 
     override suspend fun status(): Connectivity.Status {
-        return provider.monitor().first().also { status ->
+        return connectivityFlow(provider).first().also { status ->
             _statusUpdates.emit(status)
         }
     }
@@ -50,7 +52,7 @@ internal class DefaultConnectivity(
     override fun start() {
         job?.cancel()
         val started = scope.launch {
-            provider.monitor().collect { status ->
+            connectivityFlow(provider).collect { status ->
                 _statusUpdates.emit(status)
             }
         }

--- a/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/internal/DefaultConnectivityStatusEmissionTest.kt
+++ b/connectivity-core/src/commonTest/kotlin/dev/jordond/connectivity/internal/DefaultConnectivityStatusEmissionTest.kt
@@ -1,0 +1,75 @@
+package dev.jordond.connectivity.internal
+
+import dev.jordond.connectivity.Connectivity
+import dev.jordond.connectivity.ConnectivityOptions
+import dev.jordond.connectivity.ConnectivityProvider
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Pins that [DefaultConnectivity.status] publishes its result to [Connectivity.statusUpdates].
+ *
+ * This lives in its own file because [DefaultConnectivityTest] is frozen for the Phase 2 refactor,
+ * where byte-identical existing tests are the proof that reimplementing the hot API on the cold
+ * flow changed no behaviour.
+ *
+ * The behaviour matters more than it looks. `ConnectivityState.forceCheck()` in
+ * `connectivity-compose` calls `status()` and reads the result back off `statusUpdates`, so the
+ * emission is the only thing connecting the two. It is also the reason the hot API cannot be
+ * rebuilt on `shareIn`: a shared flow owns its replay cache, and nothing outside the upstream can
+ * push into it.
+ */
+class DefaultConnectivityStatusEmissionTest {
+
+    private lateinit var sutScope: TestScope
+
+    @BeforeTest
+    fun setup() {
+        sutScope = TestScope()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        sutScope.cancel()
+    }
+
+    @Test
+    fun statusPublishesItsResultToStatusUpdates() = runTest {
+        val connected = Connectivity.Status.Connected(metered = false)
+        val connectivity = createConnectivity(ConnectivityProvider(flowOf(connected)))
+
+        // Nothing has been published yet, so a later non-empty cache can only come from status().
+        connectivity.statusUpdates.replayCache.shouldBeEmpty()
+
+        val returned = connectivity.status()
+
+        returned shouldBe connected
+        connectivity.statusUpdates.replayCache shouldBe listOf(connected)
+    }
+
+    /**
+     * `status()` populates the cache without [Connectivity.start], which is the case
+     * `ConnectivityState.forceCheck()` actually exercises.
+     */
+    @Test
+    fun statusPublishesWithoutMonitoringBeingStarted() = runTest {
+        val connectivity = createConnectivity(
+            ConnectivityProvider(flowOf(Connectivity.Status.Disconnected)),
+        )
+
+        connectivity.status()
+
+        connectivity.monitoring.value shouldBe false
+        connectivity.statusUpdates.replayCache shouldBe listOf(Connectivity.Status.Disconnected)
+    }
+
+    private fun createConnectivity(provider: ConnectivityProvider): Connectivity =
+        DefaultConnectivity(sutScope, provider, ConnectivityOptions(autoStart = false))
+}

--- a/connectivity-device/src/androidMain/kotlin/dev/jordond/connectivity/MobileConnectivity.android.kt
+++ b/connectivity-device/src/androidMain/kotlin/dev/jordond/connectivity/MobileConnectivity.android.kt
@@ -11,6 +11,11 @@ import kotlinx.coroutines.CoroutineScope
  * @param scope The [CoroutineScope] in which the connectivity monitoring will be launched.
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use deviceConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public actual fun Connectivity(
     options: ConnectivityOptions,
     scope: CoroutineScope,

--- a/connectivity-device/src/appleMain/kotlin/dev/jordond/connectivity/MobileConnectivity.apple.kt
+++ b/connectivity-device/src/appleMain/kotlin/dev/jordond/connectivity/MobileConnectivity.apple.kt
@@ -11,6 +11,11 @@ import kotlinx.coroutines.CoroutineScope
  * @param scope The [CoroutineScope] in which the connectivity monitoring will be launched.
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use deviceConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public actual fun Connectivity(
     options: ConnectivityOptions,
     scope: CoroutineScope,

--- a/connectivity-device/src/commonMain/kotlin/dev/jordond/connectivity/DeviceConnectivity.kt
+++ b/connectivity-device/src/commonMain/kotlin/dev/jordond/connectivity/DeviceConnectivity.kt
@@ -12,6 +12,10 @@ import kotlinx.coroutines.Dispatchers
  * to a new [CoroutineScope] with [Dispatchers.Default].
  * @return A [Connectivity] instance.
  */
+@Deprecated(
+    "Use deviceConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public expect fun Connectivity(
     options: ConnectivityOptions = ConnectivityOptions(),
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -25,6 +29,11 @@ public expect fun Connectivity(
  * @param options A lambda function that configures the [ConnectivityOptions.Builder].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use deviceConnectivityFlow() instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     options: ConnectivityOptions.Builder.() -> Unit,

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivity.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/HttpConnectivity.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.Dispatchers
  * instance.
  * @return A [Connectivity] instance.
  */
+@Deprecated(
+    "Use httpConnectivityFlow(options, httpClient) instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     options: HttpConnectivityOptions = HttpConnectivityOptions(),
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
@@ -32,6 +36,11 @@ public fun Connectivity(
  * @param options A lambda function that configures the [HttpConnectivityOptions.Builder].
  * @return A [Connectivity] instance.
  */
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Use httpConnectivityFlow(httpClient) { ... } instead. See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity(
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
     httpClient: HttpClient = HttpClient(),
@@ -44,6 +53,10 @@ public fun Connectivity(
  * **Note:** If the [Connectivity] instance is not an [HttpConnectivity], this function will
  * do nothing.
  */
+@Deprecated(
+    "Use status(), or start a new collection of httpConnectivityFlow(...). See " +
+        "https://github.com/jordond/connectivity/blob/main/MIGRATION.md",
+)
 public fun Connectivity.force() {
     (this as? HttpConnectivity)?.forcePoll()
 }

--- a/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/internal/HttpConnectivity.kt
+++ b/connectivity-http/src/commonMain/kotlin/dev/jordond/connectivity/internal/HttpConnectivity.kt
@@ -3,12 +3,12 @@ package dev.jordond.connectivity.internal
 import dev.drewhamilton.poko.Poko
 import dev.jordond.connectivity.Connectivity
 import dev.jordond.connectivity.HttpConnectivityOptions
+import dev.jordond.connectivity.httpConnectivityFlow
 import io.ktor.client.HttpClient
 import io.ktor.http.URLProtocol
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -16,11 +16,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.milliseconds
 
 @Poko
+@Suppress("OVERRIDE_DEPRECATION")
 internal class HttpConnectivity(
     parentScope: CoroutineScope,
     private val httpOptions: HttpConnectivityOptions,
@@ -79,10 +78,8 @@ internal class HttpConnectivity(
 
     private fun poll() {
         job = scope.launch {
-            while (isActive) {
-                val status = statusChecker.check()
+            httpConnectivityFlow(httpOptions, httpClient).collect { status ->
                 _statusUpdates.emit(status)
-                delay(httpOptions.pollingIntervalMs.milliseconds)
             }
         }
     }

--- a/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/internal/HttpConnectivityStatusEmissionTest.kt
+++ b/connectivity-http/src/commonTest/kotlin/dev/jordond/connectivity/internal/HttpConnectivityStatusEmissionTest.kt
@@ -1,0 +1,79 @@
+package dev.jordond.connectivity.internal
+
+import dev.jordond.connectivity.Connectivity
+import dev.jordond.connectivity.HttpConnectivityOptions
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Pins that [HttpConnectivity.status] publishes its result to [Connectivity.statusUpdates].
+ *
+ * Separate file for the same reason as `DefaultConnectivityStatusEmissionTest`: the existing
+ * [HttpConnectivityTest] is frozen so that its byte-identity proves the Phase 2 refactor changed
+ * no behaviour.
+ */
+class HttpConnectivityStatusEmissionTest {
+
+    private lateinit var sutScope: CoroutineScope
+    private lateinit var mockEngine: MockEngine
+    private lateinit var httpClient: HttpClient
+
+    @BeforeTest
+    fun setup() {
+        sutScope = CoroutineScope(Dispatchers.Default)
+        mockEngine = MockEngine { respondOk() }
+        httpClient = HttpClient(mockEngine)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        httpClient.close()
+        mockEngine.close()
+        sutScope.cancel()
+    }
+
+    @Test
+    fun statusPublishesItsResultToStatusUpdates() = runTest {
+        val connectivity = createConnectivity()
+
+        // Nothing has been published yet, so a later non-empty cache can only come from status().
+        connectivity.statusUpdates.replayCache.shouldBeEmpty()
+
+        val returned = connectivity.status()
+
+        returned.shouldBeInstanceOf<Connectivity.Status.Connected>()
+        connectivity.statusUpdates.replayCache shouldBe listOf(returned)
+    }
+
+    /**
+     * `status()` populates the cache without [Connectivity.start], which is the case
+     * `ConnectivityState.forceCheck()` actually exercises.
+     */
+    @Test
+    fun statusPublishesWithoutPollingBeingStarted() = runTest {
+        val connectivity = createConnectivity()
+
+        connectivity.status()
+
+        connectivity.monitoring.value shouldBe false
+        connectivity.statusUpdates.replayCache.size shouldBe 1
+        mockEngine.requestHistory.size shouldBe 1
+    }
+
+    private fun createConnectivity(): Connectivity = HttpConnectivity(
+        parentScope = sutScope,
+        httpOptions = HttpConnectivityOptions.build { autoStart = false },
+        httpClient = httpClient,
+    )
+}


### PR DESCRIPTION
Reimplements the hot `Connectivity` classes on top of the cold flow factories from #264, then deprecates the hot lifecycle surface at `WARNING`. No behaviour change.

Stacked on #264, that one needs to merge first.

## Deprecations

- Factories taking a `CoroutineScope`, in core, http, device, android and apple
    - Use `connectivityFlow`, `httpConnectivityFlow`, `deviceConnectivityFlow`, `androidConnectivityFlow` or `appleConnectivityFlow`
- `Connectivity.start()`, `stop()` and `close()`
    - Collect the flow to start, cancel the collection to stop
- `Connectivity.monitoring` and `isMonitoring`
    - The collector already knows whether it is collecting, or use `SharingStarted.WhileSubscribed`
- `Connectivity.force()`
    - Use `status()`
- `rememberConnectivityState` and `ConnectivityState`'s lifecycle members
    - Use `collectAsStateWithLifecycle(null)`

`statusUpdates`, `status()`, `Status`, `ConnectivityProvider` and `ConnectivityOptions` are not deprecated.

Deprecations move to `ERROR` in 2.8.0, and the surface is deleted in 3.0.0. See MIGRATION.md for before and after examples.

## Notes

`HttpConnectivity.poll()` used to hand roll its own polling loop, it now collects `httpConnectivityFlow` instead. `DefaultConnectivity` goes through `connectivityFlow`, so `provider.monitor()` is only called in one place now.

No existing test or demo file was touched, and the API dumps are unchanged since `WARNING` deprecations do not show up in them. Added two small test files pinning that `status()` publishes to `statusUpdates`, which nothing covered before.
